### PR TITLE
add helpers to get started with fuse faster

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y curl postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
+
+COPY scripts/docker-init-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ MergeStat `fuse` is an experimental project to sync data from [`mergestat`](http
 It behaves similar to an ETL tool, taking data from git repositories and the GitHub API and regularly updating tables in a database.
 It's intended purpose is to enable "operational analytics for engineering teams," where downstream tools may consume the data from the PostgreSQL database.
 
+## Testing locally
+
+Fuse can be easily tested locally with docker compose.
+
+```sh
+# Initialize postgres and hasura
+docker-compose up init
+
+# Add a repo to be synced
+docker-compose run --rm init add-repo https://github.com/mergestat/mergestat
+
+# Start worker and grafana
+docker-compose up -d worker grafana
+```
+
+Depending on the size of the repo, it should only take short period of time to sync.
+Afterwards you should be able to pull up grafana and see some some graphs.
+
+Access grafana with http://localhost:3000
 
 ## Roadmap
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,17 +5,18 @@ services:
     image: postgres:12
     restart: always
     ports:
-      - "5432:5432"
+      - 5432:5432
     volumes:
-    - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
+
   graphql-engine:
     image: hasura/graphql-engine:v2.2.0
     ports:
-    - "8080:8080"
+      - 8080:8080
     depends_on:
-    - "postgres"
+      - postgres
     restart: always
     environment:
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:password@postgres:5432/postgres
@@ -24,14 +25,54 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+
+  init:
+    build:
+      context: .
+      dockerfile: Dockerfile.init
+    environment:
+      HASURA_GRAPHQL_ENDPOINT: http://graphql-engine:8080
+      HASURA_DATABASE_NAME: default
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: password
+      PGDATABASE: postgres
+    working_dir: /fuse
+    volumes:
+      - .:/fuse
+    depends_on:
+      - graphql-engine
+
   worker:
     build:
       context: .
     depends_on:
-      - "postgres"
-    env_file:
-      - .env
+      - postgres
     environment:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: password
+      PGDATABASE: postgres
+    ports:
+      - 3000:3000
+    depends_on:
+      - postgres
+    restart: always
+    volumes:
+      - grafana_lib:/var/lib/grafana
+      - grafana_etc:/etc/grafana
+      - grafana_log:/var/log/grafana
+      - ./scripts/grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./scripts/grafana/provisioning:/etc/grafana/provisioning
+      - ./scripts/grafana/dashboards:/var/lib/grafana/dashboards/
+
 volumes:
   db_data:
+  grafana_lib:
+  grafana_etc:
+  grafana_log:

--- a/scripts/docker-init-entrypoint.sh
+++ b/scripts/docker-init-entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+db_add_repo(){
+    local repo="$1"
+
+    local is_github="false"
+
+    if [[ "$repo" =~ ^https://github.com/ ]]; then
+        is_github="true"
+    fi
+
+    echo "Creating repo: $repo" >&2
+
+    psql -c "INSERT INTO repos (repo, is_github) VALUES ('$repo', $is_github)"
+
+    local from_repo="FROM repos WHERE repo='$repo' AND is_github=$is_github"
+    local repo_id="$(psql -Atqc "SELECT id $from_repo LIMIT 1")"
+
+    echo "Created Repo ($repo_id)" >&2
+    psql -xc "SELECT * $from_repo"
+
+    local sync_types="GIT_COMMITS GIT_COMMIT_STATS"
+
+    if [ "$is_github" == "true" ]; then
+        sync_types+=" GITHUB_REPO_METADATA"
+    fi
+
+    for sync_type in $sync_types; do
+        echo "Adding repo sync for $sync_type"
+        psql -c "INSERT INTO mergestat.repo_syncs (repo_id, sync_type) VALUES ('$repo_id', '$sync_type')"
+    done
+}
+
+if [ $# -ne 0 ]; then
+    if [ "$1" == "add-repo" ]; then
+        shift
+
+        db_add_repo "$@"
+    else
+        exec "$@"
+    fi
+
+    exit $?
+fi
+
+HASURA_DATABASE_NAME="${HASURA_DATABASE_NAME:-default}"
+HASURA_GRAPHQL_DISABLE_INTERACTIVE=true
+
+echo "Initializing Hasura..." >&2
+hasura migrate apply --database-name "$HASURA_DATABASE_NAME"
+hasura seed apply --database-name "$HASURA_DATABASE_NAME"
+hasura metadata apply

--- a/scripts/grafana/dashboards/example.json
+++ b/scripts/grafana/dashboards/example.json
@@ -1,0 +1,219 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "iteration": 1647479083365,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "left",
+              "barAlignment": 0,
+              "drawStyle": "bars",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "deletions .*"
+              },
+              "properties": [
+                {
+                  "id": "custom.transform",
+                  "value": "negative-Y"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 18,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "sum"
+            ],
+            "displayMode": "table",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "postgres",
+              "uid": "SXQZgpP7z"
+            },
+            "format": "time_series",
+            "group": [],
+            "metricColumn": "none",
+            "rawQuery": true,
+            "rawSql": "SELECT\n  $__timeGroup(commits.author_when, '$interval'),\n\tsum(commit_stats.additions) AS additions,\n\tsum(commit_stats.deletions) AS deletions,\n\tCONCAT(repo, ' ', author_name)\nFROM commits\nJOIN repos ON commits.repo_id = repos.id\nJOIN commit_stats ON commits.hash = commit_stats.commit_hash\nWHERE $__timeFilter(commits.author_when)\nGROUP BY time, repos.repo, commits.author_name\nORDER BY time",
+            "refId": "A",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "column"
+                }
+              ]
+            ],
+            "timeColumn": "time",
+            "where": [
+              {
+                "name": "$__timeFilter",
+                "params": [],
+                "type": "macro"
+              }
+            ]
+          }
+        ],
+        "title": "Additions and Deletions",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 35,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "auto": false,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          "hide": 0,
+          "label": "Interval",
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "8h",
+              "value": "8h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": true,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "1M",
+              "value": "1M"
+            }
+          ],
+          "query": "1h,8h,12h,1d,7d,14d,1M",
+          "queryValue": "",
+          "refresh": 2,
+          "skipUrlSync": false,
+          "type": "interval"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6M",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Example",
+    "uid": "4jNyRtP7y",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/scripts/grafana/grafana.ini
+++ b/scripts/grafana/grafana.ini
@@ -1,0 +1,6 @@
+[auth.anonymous]
+enabled = true
+org_role = Admin
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/example.json

--- a/scripts/grafana/provisioning/dashboards/dashboards.yaml
+++ b/scripts/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: 'MergeStat'
+    type: file
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/scripts/grafana/provisioning/datasources/postgres.yaml
+++ b/scripts/grafana/provisioning/datasources/postgres.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - uid: SXQZgpP7z
+    name: Postgres
+    type: postgres
+    access: proxy
+    url: $PGHOST
+    user: $PGUSER
+    database: $PGDATABASE
+    withCredentials: false
+    isDefault: true
+    jsonData:
+      sslmode: "disable"
+    secureJsonData:
+      password: $PGPASSWORD


### PR DESCRIPTION
An init container has been added to docker-compose.yml
to simplify initial configuration. Migration, Seeds and Metadata.

Additionally, the init container has a helper script to simplify
adding a new repo for quicker testing.

If the first argument is `add-repo` the provided repo will be
inserted and the appropriate sync types will be added.

A default grafana setup has been included as well with a simple
example dashboard with a default postgres datasource.