### PR TITLE
feat: add basic keep alive behavior

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -144,7 +144,6 @@ type GithubRepoInfo struct {
 	RepoID                   uuid.UUID
 	Owner                    string
 	Name                     string
-	Metadata                 pgtype.JSONB
 	CreatedAt                sql.NullTime
 	DefaultBranchName        sql.NullString
 	Description              sql.NullString
@@ -237,12 +236,13 @@ type MergestatRepoSyncLogType struct {
 }
 
 type MergestatRepoSyncQueue struct {
-	ID         int64
-	CreatedAt  time.Time
-	RepoSyncID uuid.UUID
-	Status     string
-	StartedAt  sql.NullTime
-	DoneAt     sql.NullTime
+	ID            int64
+	CreatedAt     time.Time
+	RepoSyncID    uuid.UUID
+	Status        string
+	StartedAt     sql.NullTime
+	DoneAt        sql.NullTime
+	LastKeepAlive sql.NullTime
 }
 
 type MergestatRepoSyncQueueStatusType struct {

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -74,3 +74,6 @@ UPDATE mergestat.repo_sync_queue SET status = $1 WHERE id = $2;
 -- name: EnqueueAllSyncs :exec
 INSERT INTO mergestat.repo_sync_queue (repo_sync_id, status)
 SELECT id, 'QUEUED' FROM mergestat.repo_syncs;
+
+-- name: SetLatestKeepAliveForJob :exec
+UPDATE mergestat.repo_sync_queue SET last_keep_alive = now() WHERE id = $1;

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -261,6 +261,15 @@ func (q *Queries) MarkRepoImportAsUpdated(ctx context.Context, id uuid.UUID) err
 	return err
 }
 
+const setLatestKeepAliveForJob = `-- name: SetLatestKeepAliveForJob :exec
+UPDATE mergestat.repo_sync_queue SET last_keep_alive = now() WHERE id = $1
+`
+
+func (q *Queries) SetLatestKeepAliveForJob(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, setLatestKeepAliveForJob, id)
+	return err
+}
+
 const setSyncJobStatus = `-- name: SetSyncJobStatus :exec
 UPDATE mergestat.repo_sync_queue SET status = $1 WHERE id = $2
 `

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -132,6 +132,9 @@ func (w *worker) exec(ctx context.Context, id string) {
 func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	w.loggerForJob(j).Info().Msg("handling job")
 
+	done := w.startKeepAlives(j, 30*time.Second)
+	defer done()
+
 	switch j.SyncType {
 	case syncTypeGitCommits:
 		return w.handleGitCommits(ctx, j)

--- a/migrations/default/1648216846523_alter_table_mergestat_repo_sync_queue_add_column_last_keep_alive/down.sql
+++ b/migrations/default/1648216846523_alter_table_mergestat_repo_sync_queue_add_column_last_keep_alive/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "mergestat"."repo_sync_queue" add column "last_keep_alive" timestamptz
+--  null;

--- a/migrations/default/1648216846523_alter_table_mergestat_repo_sync_queue_add_column_last_keep_alive/up.sql
+++ b/migrations/default/1648216846523_alter_table_mergestat_repo_sync_queue_add_column_last_keep_alive/up.sql
@@ -1,0 +1,2 @@
+alter table "mergestat"."repo_sync_queue" add column "last_keep_alive" timestamptz
+ null;

--- a/schema.sql
+++ b/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE mergestat.repo_sync_queue (
     repo_sync_id uuid NOT NULL,
     status text NOT NULL,
     started_at timestamp with time zone,
-    done_at timestamp with time zone
+    done_at timestamp with time zone,
+    last_keep_alive timestamp with time zone
 );
 CREATE VIEW mergestat.latest_repo_syncs AS
  SELECT DISTINCT ON (repo_sync_queue.repo_sync_id) repo_sync_queue.id,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -4,7 +4,7 @@ packages:
     name: "db"
     engine: "postgresql"
     sql_package: "pgx/v4"
-    schema: "migrations/default/1647540273494_init/up.sql"
+    schema: "schema.sql"
     queries: "internal/db/queries.sql"
     overrides:
       - column: "mergestat.repo_imports.import_interval"


### PR DESCRIPTION
- new column in `repo_sync_queue` table to track when the worker last "sent" a keepalive
- update worker to set the `last_keep_alive` column on an interval while a job is processing

Related to #11. This way we can have some sense of whether a job is still running or not (if the `last_keep_alive` was longer than some time ago - say 10 min - we can assume the job has timed out)