### PR TITLE
feat: update the scheduler to only requeue syncs that are not running

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -128,7 +128,7 @@ func main() {
 	}()
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
 	// TODO all of the following "params" should be configurable
 	// either via the database/app or possibly with env vars

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
 	repos "github.com/mergestat/fuse/internal/repos"
+	"github.com/mergestat/fuse/internal/scheduler"
 	"github.com/mergestat/fuse/internal/syncer"
 	"github.com/mergestat/mergestat/extensions"
 	"github.com/mergestat/mergestat/extensions/options"
@@ -131,12 +132,10 @@ func main() {
 
 	// TODO all of the following "params" should be configurable
 	// either via the database/app or possibly with env vars
-	// go func() {
-	// 	defer wg.Done()
-	// 	// TODO this should be made idempotent and generally improved
-	// 	// so it's not just a dumb "sync everything"
-	// 	// scheduler.New(&logger, pool).Start(ctx, time.Hour)
-	// }()
+	go func() {
+		defer wg.Done()
+		scheduler.New(&logger, pool).Start(ctx, 10*time.Minute)
+	}()
 
 	go func() {
 		defer wg.Done()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -26,8 +26,10 @@ func New(logger *zerolog.Logger, pool *pgxpool.Pool) *scheduler {
 func (s *scheduler) Start(ctx context.Context, interval time.Duration) {
 	s.logger.Info().Msg("starting scheduler")
 	exec := func() {
-		if err := s.db.EnqueueAllSyncs(ctx); err != nil {
+		if err := s.db.EnqueueAllCompletedSyncs(ctx); err != nil {
 			s.logger.Err(err).Msg("encountered error during scheduler execution")
+		} else {
+			s.logger.Info().Msg("re-scheduling all completed syncs to run again")
 		}
 	}
 	exec()


### PR DESCRIPTION
The scheduler will now run on some interval (10 min for now) and re-queue all syncs which are not currently running. This will need to become more robust/intelligent in the future (to support scheduled syncs based on a cron/calendar description), but for now at least avoids needing to manually requeue syncs. 