### PR TITLE
fix: update the `MarkSyncsAsTimedOut` query to handle `NULL` `last_keep_alive`

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -141,6 +141,24 @@ type GithubPullRequest struct {
 	Url                 sql.NullString
 }
 
+// GitHub pull request commits
+type GithubPullRequestCommit struct {
+	RepoID         uuid.UUID
+	PrNumber       int32
+	Hash           sql.NullString
+	Message        sql.NullString
+	AuthorName     sql.NullString
+	AuthorEmail    sql.NullString
+	AuthorWhen     sql.NullTime
+	CommitterName  sql.NullString
+	CommitterEmail sql.NullString
+	CommitterWhen  sql.NullTime
+	Additions      sql.NullInt32
+	Deletions      sql.NullInt32
+	ChangedFiles   sql.NullInt32
+	Url            sql.NullString
+}
+
 // GitHub pull request reviews
 type GithubPullRequestReview struct {
 	RepoID                    uuid.UUID

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -86,7 +86,10 @@ SELECT id, 'QUEUED' FROM mergestat.repo_syncs WHERE id NOT IN (SELECT repo_sync_
 
 -- name: MarkSyncsAsTimedOut :many
 WITH timed_out_sync_jobs AS (
-	UPDATE mergestat.repo_sync_queue SET status = 'DONE' WHERE status = 'RUNNING' AND last_keep_alive < now() - '10 minutes'::interval
+	UPDATE mergestat.repo_sync_queue SET status = 'DONE' WHERE status = 'RUNNING' AND (
+		(last_keep_alive < now() - '10 minutes'::interval)
+		OR
+		(last_keep_alive IS NULL AND created_at < now() - '10 minutes'::interval)) -- if worker crashed before last_keep_alive was first set
 	RETURNING *
 )
 INSERT INTO mergestat.repo_sync_logs (repo_sync_queue_id, log_type, message)


### PR DESCRIPTION
This should handle the case if a worker crashed before setting the first `last_keep_alive` value. Closes #26 