### PR TITLE
fix: add a longer timeout to the `golanci-lint` step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	golangci-lint run --build-tags $(TAGS)
 
 lint-ci:
-	./bin/golangci-lint run --build-tags $(TAGS) --out-format github-actions
+	./bin/golangci-lint run --build-tags $(TAGS) --out-format github-actions --timeout 5m
 
 update:
 	go get -u -tags=$(TAGS) ./...


### PR DESCRIPTION
in the GitHub action. we frequently trip the default timeout on mac os builds. Hopefully this helps avoid it.