### PR TITLE
feat: touch up some parts of the `/repos` page

### DIFF
--- a/ui/src/views/repositories/components/filter-header.tsx
+++ b/ui/src/views/repositories/components/filter-header.tsx
@@ -8,14 +8,13 @@ export const FilterHeader: React.FC = (props) => {
     <div className="flex h-14 bg-white items-center justify-between px-8">
       <div className="flex gap-2">
         <TagsListDropDown trigger={<Filter>Tags</Filter>} />
-        <Filter>Filter label</Filter>
-        <Filter>Filter label</Filter>
       </div>
 
       <Input
         placeholder="Search..."
         startIcon={<SearchIcon className="t-icon text-gray-400" />}
         className="w-1/3"
+        disabled
       />
     </div>
   )

--- a/ui/src/views/repositories/components/page-header.tsx
+++ b/ui/src/views/repositories/components/page-header.tsx
@@ -15,7 +15,7 @@ export const PageHeader: React.FC = (props) => {
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repo",
+      text: "Repositories",
       onClick: () => router.push('/repos'),
     }
   ]

--- a/ui/src/views/repositories/components/repositories-table/columns.tsx
+++ b/ui/src/views/repositories/components/repositories-table/columns.tsx
@@ -40,7 +40,7 @@ export const columns: Array<Record<string, any>> = [
       console.log(e)
     },
     render: (lastSync: string) => (
-      <span className="text-semantic-mutedText px-6">{lastSync}</span>
+      <span className="text-semantic-mutedText px-6">{lastSync || 'N/A'}</span>
     ),
   },
   {

--- a/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-status.tsx
+++ b/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-status.tsx
@@ -8,6 +8,7 @@ export type RepositoryStatusProps = {
 export const RepositoryStatus: React.FC<RepositoryStatusProps> = (props) => {
   return (
     <div className="flex items-center justify-end gap-2">
+      {props.status.length ? null : <span className="text-semantic-mutedText">No syncs</span>}
       {props.status.map((item, index) => (
         <RepoDataDropDown
           key={index}


### PR DESCRIPTION
- remove some unnecessary filter buttons
- rename `Repo` -> `Repositories`
- add "empty state" text in some spots

Address some of the items in #83 