### PR TITLE
fix: `Repo` -> `Repositories` in page title

### DIFF
--- a/ui/src/views/repository-data-details/index.tsx
+++ b/ui/src/views/repository-data-details/index.tsx
@@ -26,7 +26,7 @@ const RepoDataTypeView: React.FC<RepoDataTypeViewPropsT> = (
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repo",
+      text: "Repositories",
       onClick: () => router.push('/repos'),
     },
     {

--- a/ui/src/views/repository-data-logs-details/index.tsx
+++ b/ui/src/views/repository-data-logs-details/index.tsx
@@ -28,7 +28,7 @@ const RepoDataLogsDetailsView: React.FC<RepoDataLogsDetailsProps> =
 
     const crumbs = [
       {
-        text: "Repo",
+        text: "Repositories",
         onClick: () => router.push('/repos'),
       },
       {

--- a/ui/src/views/repository-data/components/page-header.tsx
+++ b/ui/src/views/repository-data/components/page-header.tsx
@@ -15,7 +15,7 @@ export const PageHeader = ({ name, type }: PageHeaderProps) => {
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repo",
+      text: "Repositories",
       onClick: () => router.push('/repos'),
     },
     {


### PR DESCRIPTION
small wording fix