### PR TITLE
fix: rename `lastUpdate` to `createdAt` in repo info

### DIFF
--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -23,7 +23,7 @@ export type RepoType = 'github' | 'gitlab' | 'bitbucket' | 'other'
 
 export type RepoDataPropsT = {
   name: string
-  lastUpdate: string
+  createdAt: Date
   type: RepoType
   automaticImport?: boolean
   tags: Array<{ title: string; checked: boolean }>

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -14,7 +14,7 @@ const mapToRepoData = (data: GetReposQuery | undefined): Array<RepoDataPropsT> =
     // Consolidated Repo info
     let repoInfo: RepoDataPropsT = {
       name: r?.repo.replace('https://github.com/', '') || '',
-      lastUpdate: getTimeAgoFromNow(new Date(r?.createdAt)) || '',
+      createdAt: new Date(r?.createdAt),
       lastSync: '',
       type: r?.isGithub ? 'github' : 'other',
       tags: [],

--- a/ui/src/views/repositories/components/repositories-table/columns.tsx
+++ b/ui/src/views/repositories/components/repositories-table/columns.tsx
@@ -19,7 +19,7 @@ export const columns: Array<Record<string, any>> = [
       <RepositoryName
         name={name}
         type={data.type}
-        lastUpdate={data.lastUpdate}
+        createdAt={data.createdAt}
         automaticImport={data.automaticImport}
       />
     ),

--- a/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
+++ b/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
@@ -4,11 +4,13 @@ import Link from 'next/link'
 import React from 'react'
 import type { RepoType } from 'src/@types'
 import RepoImage from 'src/components/RepoImage'
+import { getTimeAgoFromNow } from 'src/utils'
+import { format } from 'date-fns'
 
 export type RepositoryNameProps = {
   name: string
   type: RepoType
-  lastUpdate: string
+  createdAt: Date
   automaticImport?: boolean
 }
 
@@ -39,7 +41,12 @@ export const RepositoryName: React.FC<RepositoryNameProps> = (props) => {
         </Link>
         <div className="flex items-center">
           <span className="pr-2 text-sm text-semantic-mutedText">
-            {props.lastUpdate}
+            <Tooltip
+              content={`Added ${format(props.createdAt, 'PPp')}`}
+              placement='bottom'
+            >
+              {getTimeAgoFromNow(props.createdAt)}
+            </Tooltip>
           </span>
           <div className="border-l border-semantic-border px-2">
             {repoTypeIcon()}


### PR DESCRIPTION
also update the repo list with a tooltip showing the full date.

Closes out #83 