### PR TITLE
fix: address long open tx in certain syncers

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -90,7 +90,7 @@ func main() {
 		os.Exit(1)
 	}
 	v := u.Query()
-	v.Add("pool_max_conns", strconv.Itoa(concurrency))
+	v.Add("pool_max_conns", strconv.Itoa(concurrency+5))
 	u.RawQuery = v.Encode()
 
 	var pool *pgxpool.Pool

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -72,7 +72,7 @@ func collectCommits(ctx context.Context, repo *libgit2.Repository) ([]*commit, e
 		default:
 		}
 
-		var r *commit
+		var r commit
 		r.Hash = sql.NullString{String: c.Id().String(), Valid: true}
 		r.Message = sql.NullString{String: c.Message(), Valid: true}
 		r.AuthorName = sql.NullString{String: c.Author().Name, Valid: true}
@@ -83,7 +83,7 @@ func collectCommits(ctx context.Context, repo *libgit2.Repository) ([]*commit, e
 		r.CommitterWhen = sql.NullTime{Time: c.Committer().When, Valid: true}
 		r.Parents = sql.NullInt32{Int32: int32(c.ParentCount()), Valid: true}
 
-		commits = append(commits, r)
+		commits = append(commits, &r)
 
 		return true
 	}); err != nil {

--- a/internal/syncer/github_pr_commits.go
+++ b/internal/syncer/github_pr_commits.go
@@ -123,14 +123,12 @@ func (w *worker) handleGitHubPRCommits(ctx context.Context, j *db.DequeueSyncJob
 		}
 	}()
 
-	if len(commits) > 0 {
-		if _, err := tx.Exec(ctx, "DELETE FROM github_pull_request_commits WHERE repo_id = $1;", j.RepoID.String()); err != nil {
-			return fmt.Errorf("exec delete: %w", err)
-		}
+	if _, err := tx.Exec(ctx, "DELETE FROM github_pull_request_commits WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
 
-		if err := w.sendBatchGitHubPRCommits(ctx, tx, id, commits); err != nil {
-			return fmt.Errorf("batch insert pr commits: %w", err)
-		}
+	if err := w.sendBatchGitHubPRCommits(ctx, tx, id, commits); err != nil {
+		return fmt.Errorf("insert pr commits: %w", err)
 	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -9,14 +9,11 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/jmoiron/sqlx"
 	"github.com/mergestat/fuse/internal/db"
 	uuid "github.com/satori/go.uuid"
 )
 
 const (
-	issuesFullSyncDays = 90 // 90 days
-
 	selectGitHubRepoIssues = `SELECT * FROM github_repo_issues(?) ORDER BY created_at DESC`
 )
 
@@ -146,60 +143,22 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 		}
 	}()
 
-	// delete the recent rows within days for github_issues in PG
-	sql := fmt.Sprintf("DELETE FROM github_issues WHERE repo_id = $1 and created_at > (now() - interval '%d day');", issuesFullSyncDays)
-	if res, err := tx.Exec(ctx, sql, j.RepoID.String()); err != nil {
+	if res, err := tx.Exec(ctx, "DELETE FROM github_issues WHERE repo_id = $1;", j.RepoID.String()); err != nil {
 		return fmt.Errorf("delete rows: %w", err)
 	} else {
 		l.Info().Msgf("deleted rows: %d", res.RowsAffected())
 	}
 
-	sql = "SELECT database_id FROM github_issues WHERE repo_id = $1 ORDER BY created_at DESC LIMIT 1"
-	var databaseId int
-	if err := tx.QueryRow(ctx, sql, id.String()).Scan(&databaseId); err != nil {
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("query row: %w", err)
-		}
-	}
-
-	var rows *sqlx.Rows
-	if rows, err = w.mergestat.QueryxContext(ctx, selectGitHubRepoIssues, fmt.Sprintf("%s/%s", repoOwner, repoName)); err != nil {
+	issues := make([]*githubRepoIssue, 0)
+	if err = w.mergestat.SelectContext(ctx, &issues, selectGitHubRepoIssues, fmt.Sprintf("%s/%s", repoOwner, repoName)); err != nil {
 		return fmt.Errorf("mergestat query: %w", err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			w.logger.Err(err).Msgf("close rows: %v", err)
-		}
-	}()
 
-	batchSize := 500
-	batch := make([]*githubRepoIssue, 0, batchSize)
-	totalCount := 0
-	for rows.Next() {
-		var r githubRepoIssue
-		if err := rows.StructScan(&r); err != nil {
-			return fmt.Errorf("row scan: %w", err)
-		}
-		if len(batch) >= batchSize {
-			if err := w.sendBatchGitHubRepoIssues(ctx, tx, id, batch); err != nil {
-				return fmt.Errorf("batch insert issues: %w", err)
-			}
-			batch = make([]*githubRepoIssue, 0, batchSize)
-		} else {
-			if *r.DatabaseID == databaseId {
-				break
-			}
-			batch = append(batch, &r)
-		}
-		totalCount++
-	}
-	if len(batch) > 0 {
-		if err := w.sendBatchGitHubRepoIssues(ctx, tx, id, batch); err != nil {
-			return fmt.Errorf("batch insert issues: %w", err)
-		}
+	if err := w.sendBatchGitHubRepoIssues(ctx, tx, id, issues); err != nil {
+		return fmt.Errorf("insert issues: %w", err)
 	}
 
-	l.Info().Msgf("retrieved repo issues: %d", totalCount)
+	l.Info().Msgf("retrieved repo issues: %d", len(issues))
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return fmt.Errorf("sync job done: %w", err)

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -9,14 +9,11 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/jmoiron/sqlx"
 	"github.com/mergestat/fuse/internal/db"
 	uuid "github.com/satori/go.uuid"
 )
 
 const (
-	pullRequestsFullSyncDays = 90 // 90 days
-
 	selectGitHubRepoPRs = `SELECT * FROM github_repo_prs(?) ORDER BY created_at DESC`
 )
 
@@ -197,60 +194,22 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 		}
 	}()
 
-	// delete the recent rows within days for github_pull_requests in PG
-	sql := fmt.Sprintf("DELETE FROM github_pull_requests WHERE repo_id = $1 and created_at > (now() - interval '%d day');", pullRequestsFullSyncDays)
-	if res, err := tx.Exec(ctx, sql, j.RepoID.String()); err != nil {
+	if res, err := tx.Exec(ctx, "DELETE FROM github_pull_requests WHERE repo_id = $1;", j.RepoID.String()); err != nil {
 		return fmt.Errorf("delete rows: %w", err)
 	} else {
 		l.Info().Msgf("deleted rows: %d", res.RowsAffected())
 	}
 
-	var databaseId int
-	sql = "SELECT database_id FROM github_pull_requests WHERE repo_id = $1 ORDER BY created_at DESC LIMIT 1"
-	if err := tx.QueryRow(ctx, sql, id.String()).Scan(&databaseId); err != nil {
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("query row: %w", err)
-		}
-	}
-
-	var rows *sqlx.Rows
-	if rows, err = w.mergestat.QueryxContext(ctx, selectGitHubRepoPRs, fmt.Sprintf("%s/%s", repoOwner, repoName)); err != nil {
+	prs := make([]*githubRepoPR, 0)
+	if err = w.mergestat.SelectContext(ctx, &prs, selectGitHubRepoPRs, fmt.Sprintf("%s/%s", repoOwner, repoName)); err != nil {
 		return fmt.Errorf("mergestat query: %w", err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			w.logger.Err(err).Msgf("close rows: %v", err)
-		}
-	}()
 
-	batchSize := 500
-	batch := make([]*githubRepoPR, 0, batchSize)
-	totalCount := 0
-	for rows.Next() {
-		var r githubRepoPR
-		if err := rows.StructScan(&r); err != nil {
-			return fmt.Errorf("row scan: %w", err)
-		}
-		if len(batch) >= batchSize {
-			if err := w.sendBatchGitHubRepoPRs(ctx, tx, id, batch); err != nil {
-				return fmt.Errorf("batch insert prs: %w", err)
-			}
-			batch = make([]*githubRepoPR, 0, batchSize)
-		} else {
-			if *r.DatabaseID == databaseId {
-				break
-			}
-			batch = append(batch, &r)
-		}
-		totalCount++
-	}
-	if len(batch) > 0 {
-		if err := w.sendBatchGitHubRepoPRs(ctx, tx, id, batch); err != nil {
-			return fmt.Errorf("batch insert prs: %w", err)
-		}
+	if err := w.sendBatchGitHubRepoPRs(ctx, tx, id, prs); err != nil {
+		return fmt.Errorf("insert PRs: %w", err)
 	}
 
-	l.Info().Msgf("retrieved repo prs: %d", totalCount)
+	l.Info().Msgf("retrieved repo PRs: %d", len(prs))
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return fmt.Errorf("sync job done: %w", err)

--- a/internal/syncer/github_repo_stars.go
+++ b/internal/syncer/github_repo_stars.go
@@ -118,13 +118,11 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 		}
 	}()
 
-	if len(stars) > 0 {
-		if _, err := tx.Exec(ctx, "DELETE FROM github_stargazers WHERE repo_id = $1;", id.String()); err != nil {
-			return fmt.Errorf("delete stars: %w", err)
-		}
-		if err := w.sendBatchGitHubRepoStars(ctx, tx, id, stars); err != nil {
-			return fmt.Errorf("batch insert stars: %w", err)
-		}
+	if _, err := tx.Exec(ctx, "DELETE FROM github_stargazers WHERE repo_id = $1;", id.String()); err != nil {
+		return fmt.Errorf("delete stars: %w", err)
+	}
+	if err := w.sendBatchGitHubRepoStars(ctx, tx, id, stars); err != nil {
+		return fmt.Errorf("batch insert stars: %w", err)
 	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -95,6 +95,7 @@ func (w *worker) exec(ctx context.Context, id string) {
 				}
 
 				w.logger.Err(err).Msgf("error dequeuing job: %v", err)
+				continue
 			}
 
 			w.loggerForJob(j).Info().Msg("dequeued job")


### PR DESCRIPTION
in these syncers, a pg transaction is kept open while the data collection occurs (fetching from the GitHub API), leading to a long-open tx, which may be leading to blocking behavior elsewhere (in general, not great to have a long open tx if we can avoid it - which we can).