### PR TITLE
fix: standardize on `Repos` for now for consistency

### DIFF
--- a/ui/src/views/repositories/components/page-header.tsx
+++ b/ui/src/views/repositories/components/page-header.tsx
@@ -15,7 +15,7 @@ export const PageHeader: React.FC = (props) => {
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repositories",
+      text: "Repos",
       onClick: () => router.push('/repos'),
     }
   ]

--- a/ui/src/views/repository-data-details/index.tsx
+++ b/ui/src/views/repository-data-details/index.tsx
@@ -26,7 +26,7 @@ const RepoDataTypeView: React.FC<RepoDataTypeViewPropsT> = (
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repositories",
+      text: "Repos",
       onClick: () => router.push('/repos'),
     },
     {

--- a/ui/src/views/repository-data-logs-details/index.tsx
+++ b/ui/src/views/repository-data-logs-details/index.tsx
@@ -28,7 +28,7 @@ const RepoDataLogsDetailsView: React.FC<RepoDataLogsDetailsProps> =
 
     const crumbs = [
       {
-        text: "Repositories",
+        text: "Repos",
         onClick: () => router.push('/repos'),
       },
       {

--- a/ui/src/views/repository-data/components/page-header.tsx
+++ b/ui/src/views/repository-data/components/page-header.tsx
@@ -15,7 +15,7 @@ export const PageHeader = ({ name, type }: PageHeaderProps) => {
   const router = useRouter()
   const crumbs = [
     {
-      text: "Repositories",
+      text: "Repos",
       onClick: () => router.push('/repos'),
     },
     {


### PR DESCRIPTION
`Repositories` is too long for the sidebar nav, and we use `/repos` as the route, so let's standardize our page titles/breadcrumbs on `Repos` for now.