### PR TITLE
feat: add pg function for detecting errors in a sync job

### DIFF
--- a/migrations/20220804125402_sync_job_has_error.down.sql
+++ b/migrations/20220804125402_sync_job_has_error.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION mergestat.repo_sync_queue_has_error(job mergestat.repo_sync_queue);

--- a/migrations/20220804125402_sync_job_has_error.up.sql
+++ b/migrations/20220804125402_sync_job_has_error.up.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE FUNCTION mergestat.repo_sync_queue_has_error(job mergestat.repo_sync_queue) RETURNS boolean AS $$
+  SELECT EXISTS (SELECT * FROM mergestat.repo_sync_logs WHERE repo_sync_queue_id = job.id AND log_type = 'ERROR')
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
this adds a pg function that's meant to be consumed as a computed column in Graphile (https://www.graphile.org/postgraphile/computed-columns/). The function `mergestat.repo_sync_queue_has_error` (which should appear in the GraphQL query just as `hasError`) looks up whether a repo sync job has an error log, and returns a boolean `true` or `false.

Closes #96

Try this query as an example:
```graphql
{
  repos {
    nodes {
      repoSyncs {
        nodes {
          repoSyncQueues {
            nodes {
              id
              status
              hasError,
              repoSyncLogs {
                nodes {
                  logType
                  message
                }
              }
            }
          }
        }
      }
    }
  }
}

```
