### PR TITLE
fix: updates the `docker-compose.yaml` with `POSTGRAPHILE_API`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,9 @@ services:
     depends_on:
       - graphql
     ports:
-      - 3300:3000    
+      - 3300:3000
+    environment:
+      POSTGRAPHILE_API: http://graphql:5433/graphql    
 
   grafana:
     image: grafana/grafana-oss:latest


### PR DESCRIPTION
so that the UI knows where to retrieve the GraphQL API in basic local startup.

Makes `docker-compose up` work locally.