### PR TITLE
feat(github-icon): Adding link to github repository

### DIFF
--- a/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
+++ b/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import type { RepoType } from 'src/@types'
 import RepoImage from 'src/components/RepoImage'
 import { getRelativeTime } from 'src/utils'
+import { GITHUB_URL } from 'src/utils/constants'
 
 export type RepositoryNameProps = {
   id: string
@@ -23,7 +24,11 @@ export const RepositoryName: React.FC<RepositoryNameProps> = (props) => {
       case 'other':
         return <RepositoryIcon className="t-icon text-semantic-mutedIcon w-4" />
       default:
-        return <GithubIcon className="t-icon text-semantic-mutedIcon w-4" />
+        return (
+          <a target='_blank' href={GITHUB_URL + props.name} rel='noopener noreferrer'>
+            <GithubIcon className="t-icon text-semantic-mutedIcon w-4" />
+          </a>
+        )
     }
   }
 


### PR DESCRIPTION
Go to github repository when `github` icon is clicked. (Resolves #102)

![Screen Shot 2022-08-19 at 11 24 26 AM](https://user-images.githubusercontent.com/109089565/185664523-5e87b3f4-3c14-4083-a70c-ad1448feab29.png)

