### PR TITLE
chore: remove`macos` CI

### DIFF
--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -7,18 +7,11 @@ env: # environment variables (available in any part of the action)
 
 jobs:
   ui-frontend:
-    name: Build UI for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Frontend CI (UI)
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./ui
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            asset_name: mergestat-linux-amd64
-          - os: macos-latest
-            asset_name: mergestat-macos-amd64
 
     steps:
       - name: Install NodeJS

--- a/.github/workflows/ci-worker.yaml
+++ b/.github/workflows/ci-worker.yaml
@@ -2,15 +2,8 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    name: Build for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            asset_name: mergestat-linux-amd64
-          - os: macos-latest
-            asset_name: mergestat-macos-amd64
+    name: Worker CI (Golang)
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Go 1.18


### PR DESCRIPTION
This reduces the number of CI runs on commits/PRs by removing the `macos` builds - which aren't really necessary. The vast majority of deployments here should be via a container on a linux server.

Closes #140 