### PR TITLE
fix: address the "mystery crashes"

### DIFF
--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -58,24 +59,9 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 		return err
 	}
 
-	var creds *libgit2.Credential
-	if creds, err = libgit2.NewCredentialUserpassPlaintext(ghToken, ""); err != nil {
-		return err
-	}
-	defer creds.Free()
-
 	var repo *libgit2.Repository
-	if repo, err = libgit2.Clone(j.Repo, tmpPath, &libgit2.CloneOptions{
-		Bare: true,
-		FetchOptions: libgit2.FetchOptions{
-			RemoteCallbacks: libgit2.RemoteCallbacks{
-				CredentialsCallback: func(url string, username_from_url string, allowed_types libgit2.CredentialType) (*libgit2.Credential, error) {
-					return creds, nil
-				},
-			},
-		},
-	}); err != nil {
-		return err
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
 

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -112,24 +113,9 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 		return err
 	}
 
-	var creds *libgit2.Credential
-	if creds, err = libgit2.NewCredentialUserpassPlaintext(ghToken, ""); err != nil {
-		return err
-	}
-	defer creds.Free()
-
 	var repo *libgit2.Repository
-	if repo, err = libgit2.Clone(j.Repo, tmpPath, &libgit2.CloneOptions{
-		Bare: true,
-		FetchOptions: libgit2.FetchOptions{
-			RemoteCallbacks: libgit2.RemoteCallbacks{
-				CredentialsCallback: func(url string, username_from_url string, allowed_types libgit2.CredentialType) (*libgit2.Credential, error) {
-					return creds, nil
-				},
-			},
-		},
-	}); err != nil {
-		return err
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
 

--- a/internal/syncer/git_files.go
+++ b/internal/syncer/git_files.go
@@ -71,23 +71,8 @@ func (w *worker) handleGitFiles(ctx context.Context, j *db.DequeueSyncJobRow) er
 		return err
 	}
 
-	var creds *libgit2.Credential
-	if creds, err = libgit2.NewCredentialUserpassPlaintext(ghToken, ""); err != nil {
-		return err
-	}
-	defer creds.Free()
-
 	var repo *libgit2.Repository
-	if repo, err = libgit2.Clone(j.Repo, tmpPath, &libgit2.CloneOptions{
-		Bare: true,
-		FetchOptions: libgit2.FetchOptions{
-			RemoteCallbacks: libgit2.RemoteCallbacks{
-				CredentialsCallback: func(url string, username_from_url string, allowed_types libgit2.CredentialType) (*libgit2.Credential, error) {
-					return creds, nil
-				},
-			},
-		},
-	}); err != nil {
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_refs.go
+++ b/internal/syncer/git_refs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -94,24 +95,9 @@ func (w *worker) handleGitRefs(ctx context.Context, j *db.DequeueSyncJobRow) err
 		return err
 	}
 
-	var creds *libgit2.Credential
-	if creds, err = libgit2.NewCredentialUserpassPlaintext(ghToken, ""); err != nil {
-		return err
-	}
-	defer creds.Free()
-
 	var repo *libgit2.Repository
-	if repo, err = libgit2.Clone(j.Repo, tmpPath, &libgit2.CloneOptions{
-		Bare: true,
-		FetchOptions: libgit2.FetchOptions{
-			RemoteCallbacks: libgit2.RemoteCallbacks{
-				CredentialsCallback: func(url string, username_from_url string, allowed_types libgit2.CredentialType) (*libgit2.Credential, error) {
-					return creds, nil
-				},
-			},
-		},
-	}); err != nil {
-		return err
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
 


### PR DESCRIPTION
Closes #158

Basically, we've discovered the `libgit2` (or how `git2go` calls it) will crash if credentials are used with an empty string `""` as the user. This should avoid that scenario in the code to prevent those crashes.

Now, if a token is _not_ supplied either by an env var or the database, instead of crashing, a standard error will be reported:

```
{"level":"error","error":"git clone: remote authentication required but no callback set","time":"2022-08-30T15:36:18Z","message":"error handling job: &{1822 2022-08-30 15:30:26.436473 +0000 UTC RUNNING 3a3b6bfe-f211-46df-bc11-a6fb584eae6e 83559d70-0220-428a-8f70-cf807240284c GIT_FILES {[123 125] 2} 3a3b6bfe-f211-46df-bc11-a6fb584eae6e https://github.com/mergestat/query-broker { false} {true true} {[123 125] 2}}"}
```