### PR TITLE
feat: add `replaceGitHubPAT` mutation to GraphQL API

### DIFF
--- a/docker-compose.ui-dev.yaml
+++ b/docker-compose.ui-dev.yaml
@@ -15,7 +15,7 @@ services:
       - "--schema"
       - "mergestat,public"
       - "--append-plugins"
-      - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js"
+      - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js,/graphql/service-credentials/index.js"
       - "-o"
       - "--subscriptions"
       - "--watch"
@@ -28,3 +28,5 @@ services:
       - "--allow-explain"
       - "--enable-query-batching"
       - "--legacy-relations=omit"
+    environment:
+      FUSE_SECRET: password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     environment:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       GITHUB_RATE_LIMIT: 1/2
+      FUSE_SECRET: password
     env_file:
       - .env-worker
     ports:
@@ -41,7 +42,7 @@ services:
       - "--schema"
       - "mergestat,public"
       - "--append-plugins"
-      - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js"
+      - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js,/graphql/service-credentials/index.js"
       - "-o"
       - "--subscriptions"
       - "--retry-on-init-fail"
@@ -53,6 +54,8 @@ services:
       - "--enable-query-batching"
       - "--disable-query-log"
       - "--legacy-relations=omit"
+    environment:
+      FUSE_SECRET: password
 
   ui:
     restart: always

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -2,9 +2,12 @@ FROM node:alpine
 LABEL description="Instant high-performance GraphQL API for your PostgreSQL database https://github.com/graphile/postgraphile"
 
 WORKDIR /graphql
-COPY . /graphql
 
+COPY exec-sql/ /graphql/exec-sql
 RUN cd exec-sql && npm i && npm run build
+
+COPY service-credentials/ /graphql/service-credentials
+RUN cd service-credentials && npm i && npm run build
 
 # Install PostGraphile and PostGraphile connection filter plugin
 RUN npm install -g postgraphile

--- a/graphql/service-credentials/index.js
+++ b/graphql/service-credentials/index.js
@@ -1,0 +1,46 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const graphile_utils_1 = require("graphile-utils");
+// FUSE_SECRET is used to encrypt credentials before they go into the DB
+const { FUSE_SECRET } = process.env;
+module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
+    typeDefs: (0, graphile_utils_1.gql) `
+    extend type Mutation {
+      replaceGitHubPAT(pat: String!): Boolean
+    }
+  `,
+    resolvers: {
+        Mutation: {
+            replaceGitHubPAT(_parent, args, context, _info) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    try {
+                        yield context.pgClient.query('BEGIN');
+                        // first delete all the existing PATs in the DB (for now, only allow one at a time)
+                        // TODO(patrickdevivo) this may eventually make more sense to handle with unique constraints/indexes in the DB
+                        // however the encryption adds a wrinkle to that
+                        yield context.pgClient.query("DELETE FROM mergestat.service_auth_credentials WHERE type = 'GITHUB_PAT'");
+                        // then do an insert using the add_service_auth_credential helper in the DB
+                        yield context.pgClient.query("SELECT mergestat.add_service_auth_credential('GITHUB_PAT', $1, $2)", [args.pat, FUSE_SECRET]);
+                        yield context.pgClient.query('COMMIT');
+                    }
+                    catch (e) {
+                        yield context.pgClient.query('ROLLBACK');
+                        throw e;
+                    }
+                    finally {
+                        return true;
+                    }
+                });
+            },
+        },
+    },
+});

--- a/graphql/service-credentials/index.js
+++ b/graphql/service-credentials/index.js
@@ -23,17 +23,17 @@ module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
             replaceGitHubPAT(_parent, args, context, _info) {
                 return __awaiter(this, void 0, void 0, function* () {
                     try {
-                        yield context.pgClient.query('BEGIN');
+                        yield context.pgClient.query('SAVEPOINT replaceGitHubPAT;');
                         // first delete all the existing PATs in the DB (for now, only allow one at a time)
                         // TODO(patrickdevivo) this may eventually make more sense to handle with unique constraints/indexes in the DB
                         // however the encryption adds a wrinkle to that
                         yield context.pgClient.query("DELETE FROM mergestat.service_auth_credentials WHERE type = 'GITHUB_PAT'");
                         // then do an insert using the add_service_auth_credential helper in the DB
                         yield context.pgClient.query("SELECT mergestat.add_service_auth_credential('GITHUB_PAT', $1, $2)", [args.pat, FUSE_SECRET]);
-                        yield context.pgClient.query('COMMIT');
+                        yield context.pgClient.query('RELEASE SAVEPOINT replaceGitHubPAT;');
                     }
                     catch (e) {
-                        yield context.pgClient.query('ROLLBACK');
+                        yield context.pgClient.query('ROLLBACK TO SAVEPOINT replaceGitHubPAT;');
                         throw e;
                     }
                     finally {

--- a/graphql/service-credentials/index.ts
+++ b/graphql/service-credentials/index.ts
@@ -1,0 +1,41 @@
+import { makeExtendSchemaPlugin, gql } from "graphile-utils"
+import { Client } from 'pg'
+
+// FUSE_SECRET is used to encrypt credentials before they go into the DB
+const { FUSE_SECRET } = process.env
+
+type ReplaceGitHubPATInput = {
+  pat: string
+}
+
+module.exports = makeExtendSchemaPlugin({
+  typeDefs: gql`
+    extend type Mutation {
+      replaceGitHubPAT(pat: String!): Boolean
+    }
+  `,
+  resolvers: {
+    Mutation: {
+      async replaceGitHubPAT(_parent: any, args: ReplaceGitHubPATInput, context: { pgClient: Client }, _info: any) {
+        try {
+          await context.pgClient.query('BEGIN')
+
+          // first delete all the existing PATs in the DB (for now, only allow one at a time)
+          // TODO(patrickdevivo) this may eventually make more sense to handle with unique constraints/indexes in the DB
+          // however the encryption adds a wrinkle to that
+          await context.pgClient.query("DELETE FROM mergestat.service_auth_credentials WHERE type = 'GITHUB_PAT'")
+          
+          // then do an insert using the add_service_auth_credential helper in the DB
+          await context.pgClient.query("SELECT mergestat.add_service_auth_credential('GITHUB_PAT', $1, $2)", [ args.pat, FUSE_SECRET ])
+
+          await context.pgClient.query('COMMIT')
+        } catch (e) {
+          await context.pgClient.query('ROLLBACK')
+          throw e
+        } finally {
+          return true
+        }
+      },
+    },
+  },
+});

--- a/graphql/service-credentials/package-lock.json
+++ b/graphql/service-credentials/package-lock.json
@@ -1,0 +1,1077 @@
+{
+    "name": "@mergestat/fuse-service-credentials",
+    "version": "0.0.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@mergestat/fuse-service-credentials",
+            "version": "0.0.1",
+            "dependencies": {
+                "graphile-utils": "^4.12.3"
+            },
+            "devDependencies": {
+                "@types/node": "^18.7.1",
+                "@types/pg": "^8.6.5",
+                "@types/pg-cursor": "^2.7.0",
+                "typescript": "^4.7.4"
+            }
+        },
+        "node_modules/@graphile/lru": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@graphile/lru/-/lru-4.11.0.tgz",
+            "integrity": "sha512-Fakuk190EAKxWSa9YQyr/87g8mvAv8HBvk6yPCPuIoA3bYXF7n6kl0XSqKjSd5VfjEqhtnzQ6zJGzDf1Gv/tJg==",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "18.7.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+            "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
+        },
+        "node_modules/@types/pg": {
+            "version": "8.6.5",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+            "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@types/pg-cursor": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.0.tgz",
+            "integrity": "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/pg": "*"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "peer": true
+        },
+        "node_modules/buffer-writer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "peer": true
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/graphile-build": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-build/-/graphile-build-4.12.3.tgz",
+            "integrity": "sha512-xwNNNrieWm78DVkB29epKLBAMEd5U9nXY1tQQn2n5pMisbqYMtIQOnfZzLhwM6AsNEyAfaQYyV0fD6wCkyYQpA==",
+            "peer": true,
+            "dependencies": {
+                "@graphile/lru": "4.11.0",
+                "chalk": "^2.4.2",
+                "debug": "^4.1.1",
+                "graphql-parse-resolve-info": "4.12.3",
+                "iterall": "^1.2.2",
+                "lodash": ">=4 <5",
+                "lru-cache": "^5.0.0",
+                "pluralize": "^7.0.0",
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8.6"
+            },
+            "peerDependencies": {
+                "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
+            }
+        },
+        "node_modules/graphile-build-pg": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-build-pg/-/graphile-build-pg-4.12.3.tgz",
+            "integrity": "sha512-Gnwwxm2NRuyxOx5xchU+Po9a6XagRJpEgoezzHmfBRHwFBY2zprCMYdLvllqRrPJBBWdYAjx7H1NxctBiYiIoQ==",
+            "peer": true,
+            "dependencies": {
+                "@graphile/lru": "4.11.0",
+                "chalk": "^2.4.2",
+                "debug": "^4.1.1",
+                "graphile-build": "4.12.3",
+                "jsonwebtoken": "^8.5.1",
+                "lodash": ">=4 <5",
+                "lru-cache": ">=4 <5",
+                "pg-sql2": "4.12.3"
+            },
+            "engines": {
+                "node": ">=8.6"
+            },
+            "peerDependencies": {
+                "pg": ">=6.1.0 <9"
+            }
+        },
+        "node_modules/graphile-build-pg/node_modules/lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "peer": true,
+            "dependencies": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "node_modules/graphile-build-pg/node_modules/yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+            "peer": true
+        },
+        "node_modules/graphile-utils": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-utils/-/graphile-utils-4.12.3.tgz",
+            "integrity": "sha512-Kls1TNZnPAZ3iLphTTagB+xM+EP+ry33o+4s1vEkl0JE1c0B8ztVTfs3fUl04vyQ2q1K24QTwLYrJ4LN8+Xbuw==",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0",
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            },
+            "peerDependencies": {
+                "graphile-build": "^4.5.0",
+                "graphile-build-pg": "^4.5.0"
+            }
+        },
+        "node_modules/graphql": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+            "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/graphql-parse-resolve-info": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.12.3.tgz",
+            "integrity": "sha512-Lxb+v+SCxzBZHKohK4xje3CBQ1iZ968DiKuFtmwzSaI45oP8FgPJjJv35TOzgv73QLijEdgH4NDZGwIvwJM7Kw==",
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            },
+            "peerDependencies": {
+                "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "peer": true
+        },
+        "node_modules/jsonwebtoken": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "peer": true,
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
+            },
+            "engines": {
+                "node": ">=4",
+                "npm": ">=1.4.28"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "peer": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "peer": true,
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "peer": true
+        },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "peer": true
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "peer": true
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "peer": true
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "peer": true
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "peer": true
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "peer": true
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "peer": true
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "peer": true,
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/packet-reader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+            "peer": true
+        },
+        "node_modules/pg": {
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+            "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+            "peer": true,
+            "dependencies": {
+                "buffer-writer": "2.0.0",
+                "packet-reader": "1.0.0",
+                "pg-connection-string": "^2.5.0",
+                "pg-pool": "^3.5.2",
+                "pg-protocol": "^1.5.0",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "pg-native": ">=3.0.1"
+            },
+            "peerDependenciesMeta": {
+                "pg-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/pg-connection-string": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+            "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+            "peer": true
+        },
+        "node_modules/pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pg-pool": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+            "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+            "peer": true,
+            "peerDependencies": {
+                "pg": ">=8.0"
+            }
+        },
+        "node_modules/pg-protocol": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+            "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+        },
+        "node_modules/pg-sql2": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/pg-sql2/-/pg-sql2-4.12.3.tgz",
+            "integrity": "sha512-xPVNoN7O5fT9ssq+j/IRbq0OOtD7Sagz0Xbzb5Z6M3T5cU1pi43QdBv6nvZ7wIuvi/iSq2/02wYridSp7B69EQ==",
+            "peer": true,
+            "dependencies": {
+                "@graphile/lru": "4.11.0",
+                "@types/pg": ">=6 <9",
+                "debug": ">=3 <5",
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            },
+            "peerDependencies": {
+                "pg": ">=6.1.0 <9"
+            }
+        },
+        "node_modules/pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "dependencies": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pgpass": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+            "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+            "peer": true,
+            "dependencies": {
+                "split2": "^4.1.0"
+            }
+        },
+        "node_modules/pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postgres-bytea": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+            "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "dependencies": {
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+            "peer": true
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
+        "node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/split2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+            "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+            "peer": true,
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "node_modules/typescript": {
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "peer": true
+        }
+    },
+    "dependencies": {
+        "@graphile/lru": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@graphile/lru/-/lru-4.11.0.tgz",
+            "integrity": "sha512-Fakuk190EAKxWSa9YQyr/87g8mvAv8HBvk6yPCPuIoA3bYXF7n6kl0XSqKjSd5VfjEqhtnzQ6zJGzDf1Gv/tJg==",
+            "peer": true,
+            "requires": {
+                "tslib": "^2.0.1"
+            }
+        },
+        "@types/node": {
+            "version": "18.7.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+            "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
+        },
+        "@types/pg": {
+            "version": "8.6.5",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+            "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+            "requires": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
+        "@types/pg-cursor": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.0.tgz",
+            "integrity": "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/pg": "*"
+            }
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "peer": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "peer": true
+        },
+        "buffer-writer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+            "peer": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "peer": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "peer": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "peer": true
+        },
+        "debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "peer": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "peer": true
+        },
+        "graphile-build": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-build/-/graphile-build-4.12.3.tgz",
+            "integrity": "sha512-xwNNNrieWm78DVkB29epKLBAMEd5U9nXY1tQQn2n5pMisbqYMtIQOnfZzLhwM6AsNEyAfaQYyV0fD6wCkyYQpA==",
+            "peer": true,
+            "requires": {
+                "@graphile/lru": "4.11.0",
+                "chalk": "^2.4.2",
+                "debug": "^4.1.1",
+                "graphql-parse-resolve-info": "4.12.3",
+                "iterall": "^1.2.2",
+                "lodash": ">=4 <5",
+                "lru-cache": "^5.0.0",
+                "pluralize": "^7.0.0",
+                "semver": "^6.0.0"
+            }
+        },
+        "graphile-build-pg": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-build-pg/-/graphile-build-pg-4.12.3.tgz",
+            "integrity": "sha512-Gnwwxm2NRuyxOx5xchU+Po9a6XagRJpEgoezzHmfBRHwFBY2zprCMYdLvllqRrPJBBWdYAjx7H1NxctBiYiIoQ==",
+            "peer": true,
+            "requires": {
+                "@graphile/lru": "4.11.0",
+                "chalk": "^2.4.2",
+                "debug": "^4.1.1",
+                "graphile-build": "4.12.3",
+                "jsonwebtoken": "^8.5.1",
+                "lodash": ">=4 <5",
+                "lru-cache": ">=4 <5",
+                "pg-sql2": "4.12.3"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "peer": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+                    "peer": true
+                }
+            }
+        },
+        "graphile-utils": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphile-utils/-/graphile-utils-4.12.3.tgz",
+            "integrity": "sha512-Kls1TNZnPAZ3iLphTTagB+xM+EP+ry33o+4s1vEkl0JE1c0B8ztVTfs3fUl04vyQ2q1K24QTwLYrJ4LN8+Xbuw==",
+            "requires": {
+                "debug": "^4.1.1",
+                "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0",
+                "tslib": "^2.0.1"
+            }
+        },
+        "graphql": {
+            "version": "15.8.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+            "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+        },
+        "graphql-parse-resolve-info": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.12.3.tgz",
+            "integrity": "sha512-Lxb+v+SCxzBZHKohK4xje3CBQ1iZ968DiKuFtmwzSaI45oP8FgPJjJv35TOzgv73QLijEdgH4NDZGwIvwJM7Kw==",
+            "peer": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "tslib": "^2.0.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "peer": true
+        },
+        "iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "peer": true
+        },
+        "jsonwebtoken": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "peer": true,
+            "requires": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "peer": true
+                }
+            }
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "peer": true,
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "peer": true,
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "peer": true
+        },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "peer": true
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "peer": true
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "peer": true
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "peer": true
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "peer": true
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "peer": true
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "peer": true
+        },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "peer": true,
+            "requires": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "packet-reader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+            "peer": true
+        },
+        "pg": {
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+            "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+            "peer": true,
+            "requires": {
+                "buffer-writer": "2.0.0",
+                "packet-reader": "1.0.0",
+                "pg-connection-string": "^2.5.0",
+                "pg-pool": "^3.5.2",
+                "pg-protocol": "^1.5.0",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x"
+            }
+        },
+        "pg-connection-string": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+            "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+            "peer": true
+        },
+        "pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+        },
+        "pg-pool": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+            "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+            "peer": true,
+            "requires": {}
+        },
+        "pg-protocol": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+            "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+        },
+        "pg-sql2": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/pg-sql2/-/pg-sql2-4.12.3.tgz",
+            "integrity": "sha512-xPVNoN7O5fT9ssq+j/IRbq0OOtD7Sagz0Xbzb5Z6M3T5cU1pi43QdBv6nvZ7wIuvi/iSq2/02wYridSp7B69EQ==",
+            "peer": true,
+            "requires": {
+                "@graphile/lru": "4.11.0",
+                "@types/pg": ">=6 <9",
+                "debug": ">=3 <5",
+                "tslib": "^2.0.1"
+            }
+        },
+        "pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "requires": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            }
+        },
+        "pgpass": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+            "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+            "peer": true,
+            "requires": {
+                "split2": "^4.1.0"
+            }
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "peer": true
+        },
+        "postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+        },
+        "postgres-bytea": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+            "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+        },
+        "postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+        },
+        "postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "requires": {
+                "xtend": "^4.0.0"
+            }
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+            "peer": true
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "peer": true
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "peer": true
+        },
+        "split2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+            "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+            "peer": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "peer": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "typescript": {
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "peer": true
+        }
+    }
+}

--- a/graphql/service-credentials/package.json
+++ b/graphql/service-credentials/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@mergestat/fuse-service-credentials",
+    "version": "0.0.1",
+    "description": "Graphile plugin for managing service credentials",
+    "main": "index.js",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "graphile-utils": "^4.12.3"
+    },
+    "devDependencies": {
+        "@types/node": "^18.7.1",
+        "@types/pg": "^8.6.5",
+        "@types/pg-cursor": "^2.7.0",
+        "typescript": "^4.7.4"
+    }
+}

--- a/graphql/service-credentials/tsconfig.json
+++ b/graphql/service-credentials/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Implements a Graphile `makeExtendSchemaPlugin` that adds a mutation called `replaceGitHubPAT` which will allow us to set a GitHub PAT auth method from the UI. Authentication will need to be handled here eventually as well.

Closes #159 