### PR TITLE
Sign all container images with sigstore's cosign

### DIFF
--- a/.github/workflows/publish-graphql-docker.yaml
+++ b/.github/workflows/publish-graphql-docker.yaml
@@ -12,6 +12,9 @@ jobs:
     # only publish docker image if the PR is from a MergeStat repo
     if: github.repository_owner == 'mergestat'
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to get a GitHub OIDC token.
+      id-token: write
     steps:
       -
         name: Docker meta
@@ -36,6 +39,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - 
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v2.5.1
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -50,3 +58,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - 
+        name: Sign the images with GitHub OIDC Token
+        run: cosign sign ${TAGS}
+        env:
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          COSIGN_EXPERIMENTAL: true
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/publish-ui-docker.yaml
+++ b/.github/workflows/publish-ui-docker.yaml
@@ -12,6 +12,9 @@ jobs:
     # only publish docker image if the PR is from a MergeStat repo
     if: github.repository_owner == 'mergestat'
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to get a GitHub OIDC token.
+      id-token: write
     steps:
       -
         name: Docker meta
@@ -36,6 +39,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - 
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v2.5.1
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -50,3 +58,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - 
+        name: Sign the images with GitHub OIDC Token
+        run: cosign sign ${TAGS}
+        env:
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          COSIGN_EXPERIMENTAL: true
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/publish-worker-docker.yaml
+++ b/.github/workflows/publish-worker-docker.yaml
@@ -12,6 +12,9 @@ jobs:
     # only publish docker image if the PR is from a MergeStat repo
     if: github.repository_owner == 'mergestat'
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to get a GitHub OIDC token.
+      id-token: write
     steps:
       -
         name: Docker meta
@@ -36,6 +39,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - 
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v2.5.1
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -49,3 +57,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      
+      - 
+        name: Sign the images with GitHub OIDC Token
+        run: cosign sign ${TAGS}
+        env:
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          COSIGN_EXPERIMENTAL: true
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+


### PR DESCRIPTION
This uses cosign to sign the graphql, UI and worker images. Cosign is
configured to use keyless signing and will use a GitHub OIDC token
provided to the workflow in order to request a certificate and do the
signature.

Signatures are posted to a public transparency log (rekor.sigstore.dev)
and the signature itself is pushed to the same repository as the images
themselves.

To verify, do:

    COSIGN_EXPERIMENTAL=1 cosign verify <image name>

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
