### PR TITLE
feat: implement a `TRIVY_REPO_SCAN` sync type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY migrations migrations
 
 COPY scripts/docker-init-entrypoint.sh docker-init-entrypoint.sh
 
+# install trivy binary for `TRIVY_REPO_SCAN` sync type
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.31.3
+
+
 # for pprof and prom metrics over http
 EXPOSE 8080
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -30,6 +30,7 @@ const (
 	syncTypeGitHubRepoStars    = "GITHUB_REPO_STARS"
 	syncTypeGitHubPRReviews    = "GITHUB_PR_REVIEWS"
 	syncTypeGitHubPRCommits    = "GITHUB_PR_COMMITS"
+	syncTypeTrivyRepoScan      = "TRIVY_REPO_SCAN"
 )
 
 type worker struct {
@@ -162,6 +163,8 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleGitHubPRReviews(ctx, j)
 	case syncTypeGitHubPRCommits:
 		return w.handleGitHubPRCommits(ctx, j)
+	case syncTypeTrivyRepoScan:
+		return w.handleTrivyRepoScan(ctx, j)
 	default:
 		return fmt.Errorf("unknown sync type: %s for job ID: %d", j.SyncType, j.ID)
 	}

--- a/internal/syncer/trivy_repo_scan.go
+++ b/internal/syncer/trivy_repo_scan.go
@@ -1,0 +1,81 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/mergestat/fuse/internal/db"
+)
+
+// handleTrivyRepoScan executes `trivy repo {git-repo} -f json` for a repo
+// and inserts the output JSON into the DB
+func (w *worker) handleTrivyRepoScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	var ghToken string
+	var err error
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{
+		{
+			Type:            SyncLogTypeInfo,
+			RepoSyncQueueID: j.ID,
+			Message:         "starting to execute trivy scan",
+		},
+	}); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "trivy", "repository", j.Repo, "-q", "-f", "json")
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", ghToken))
+
+	var output []byte
+	if output, err = cmd.Output(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			w.logger.Err(exitErr).Msgf("error running trivy scan")
+		}
+		return fmt.Errorf("running trivy scan: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, "DELETE FROM trivy_repo_scans WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, "INSERT INTO trivy_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, output); err != nil {
+		return fmt.Errorf("inserting trivy results: %w", err)
+	}
+
+	l.Info().Msg("inserted trivy scan results")
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{
+		{
+			Type:            SyncLogTypeInfo,
+			RepoSyncQueueID: j.ID,
+			Message:         "finished",
+		},
+	}); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/migrations/20220902164407_trivy_scan_sync_type.down.sql
+++ b/migrations/20220902164407_trivy_scan_sync_type.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DROP VIEW trivy_repo_vulnerabilities;
+
+DROP TABLE trivy_repo_scans;
+
+-- NOTE: this does not remove the `TRIVY_REPO_SCAN` sync type nor any trivy repo scan syncs in the history
+-- DELETE FROM mergestat.repo_sync_types WHERE type = 'TRIVY_REPO_SCAN';
+
+COMMIT;

--- a/migrations/20220902164407_trivy_scan_sync_type.up.sql
+++ b/migrations/20220902164407_trivy_scan_sync_type.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('TRIVY_REPO_SCAN', 'Executes a trivy scan on a git repository', 'Trivy Repo Scan') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS trivy_repo_scans (
+    repo_id uuid PRIMARY KEY,
+    results JSONB NOT NULL
+);
+
+CREATE OR REPLACE VIEW trivy_repo_vulnerabilities AS
+SELECT
+	trivy_repo_scans.repo_id,
+	r.value->>'Target' as target,
+	r.value->>'Class' as class,
+	r.value->>'Type' as type,
+	v as vulnerability,
+	v->>'VulnerabilityID' as vulnerability_id,
+	v->>'PkgName' as vulnerability_pkg_name,
+	v->>'InstalledVersion' as vulnerability_installed_version,
+	v->>'Severity' as vulnerability_severity,
+	v->>'Title' as vulnerability_title,
+	v->>'Description' as vulnerability_description
+FROM trivy_repo_scans, jsonb_array_elements(results->'Results') r, jsonb_array_elements(r->'Vulnerabilities') v;
+
+COMMIT;


### PR DESCRIPTION
Sync type that runs `trivy repo ... -f json` and stashes the JSON output in the DB. Also includes a view to help extract common fields from the resulting JSON.

In general this is not a scalable way for us to continue adding sync types. However, for our current purposes this is sufficient to demonstrate the _types_ of syncs we want to continue building support for. We will soon need a better architecture and pattern for supporting arbitrary "3rd party" data sources such as `trivy` in a scalable and flexible way. That design is ongoing.