### PR TITLE
chore: add a log line to the trivy scans, if there's an error

### DIFF
--- a/internal/syncer/trivy_repo_scan.go
+++ b/internal/syncer/trivy_repo_scan.go
@@ -37,7 +37,7 @@ func (w *worker) handleTrivyRepoScan(ctx context.Context, j *db.DequeueSyncJobRo
 	var output []byte
 	if output, err = cmd.Output(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			w.logger.Err(exitErr).Msgf("error running trivy scan")
+			w.logger.Err(exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running trivy scan")
 		}
 		return fmt.Errorf("running trivy scan: %w", err)
 	}


### PR DESCRIPTION
if there's an exit error when running trivy, report what was on `stderr` to the log output