### PR TITLE
some small `worker` tweaks

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -65,10 +65,11 @@ func repoLocator() services.RepoLocator {
 // }
 
 func main() {
+	debug := os.Getenv("DEBUG") == "1"
 	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 
-	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 || os.Getenv("DEBUG") == "1" {
-		l := logger.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.Stamp})
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 || debug {
+		l := logger.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.Stamp}).Level(zerolog.DebugLevel)
 		logger = l
 	}
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -67,7 +67,7 @@ func repoLocator() services.RepoLocator {
 func main() {
 	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 
-	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 || os.Getenv("DEBUG") == "1" {
 		l := logger.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.Stamp})
 		logger = l
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       context: ./graphql
     depends_on:
       - postgres
+      - worker # this is to ensure all migrations are run before the API starts up
     ports:
       - 5433:5433
     command:

--- a/internal/repos/importer.go
+++ b/internal/repos/importer.go
@@ -39,6 +39,7 @@ func NewImporter(logger *zerolog.Logger, pool *pgxpool.Pool, mergestat *sqlx.DB)
 func (i *importer) Start(ctx context.Context, interval time.Duration) {
 	i.logger.Info().Msg("beginning repo import cycle")
 	exec := func() {
+		i.logger.Debug().Msg("executing repo import check")
 		if err := i.exec(ctx); err != nil {
 			i.logger.Err(err).Msg("encountered error during repo import")
 		}

--- a/internal/repos/importer.go
+++ b/internal/repos/importer.go
@@ -60,7 +60,7 @@ func (i *importer) Start(ctx context.Context, interval time.Duration) {
 func (i *importer) exec(ctx context.Context) error {
 	var imports []db.ListRepoImportsDueForImportRow
 	var err error
-	if imports, err = db.New(i.pool).ListRepoImportsDueForImport(ctx); err != nil {
+	if imports, err = i.db.ListRepoImportsDueForImport(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Some minor changes I made when taking a look running things locally. adds support for `DEBUG=1` for cleaner local log output (including enabling the `Debug` log level)