### PR TITLE
feat(list-all-syncs): Listing all available sync types for any repo

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,7 +50,7 @@
         "autoprefixer": "^10.4.4",
         "cross-env": "^7.0.3",
         "eslint": "^8.21.0",
-        "eslint-config-next": "^12.2.4",
+        "eslint-config-next": "^12.3.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-import-resolver-typescript": "^2.5.0",
@@ -2524,9 +2524,9 @@
       "integrity": "sha512-/gApFXWk5CCLFQJL5IYJXxPQuG5tz5nPX4l27A9Zm/+wJxiwFrRSP54AopDxIv4JRp/rGwcgk/lZS/0Clw8jYA=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.5.tgz",
-      "integrity": "sha512-VBjVbmqEzGiOTBq4+wpeVXt/KgknnGB6ahvC/AxiIGnN93/RCSyXhFRI4uSfftM2Ba3w7ZO7076bfKasZsA0fw==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.0.tgz",
+      "integrity": "sha512-jVdq1qYTNDjUtulnE8/hkPv0pHILV4jMg5La99iaY/FFm20WxVnsAZtbNnMvlPbf8dc010oO304SX9yXbg5PAw==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -5473,12 +5473,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.2.4.tgz",
-      "integrity": "sha512-r3keSLY1Z+rN+ASN8nmWwZ+AsMl6IrPGRWgbQhKHcop4/fk1hJGxE9Xf/mYMkV07+1Q/catchw25lu525HFy5Q==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.0.tgz",
+      "integrity": "sha512-guHSkNyKnTBB8HU35COgAMeMV0E026BiYRYvyEVVaTOeFcnU3i1EI8/Da0Rl7H3Sgua5FEvoA0vYd2s8kdIUXg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.2.4",
+        "@next/eslint-plugin-next": "12.3.0",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -5496,35 +5496,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/@next/eslint-plugin-next": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.4.tgz",
-      "integrity": "sha512-ChDkUIkJeYWKRx+FdF+EhUgvKtK1wF+Xew4Os7ef3iAjMch5GGBiezw2zGXTa/C0E6potz4j11EpX89mngffug==",
-      "dev": true,
-      "dependencies": {
-        "glob": "7.1.7"
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -14233,9 +14204,9 @@
       "integrity": "sha512-/gApFXWk5CCLFQJL5IYJXxPQuG5tz5nPX4l27A9Zm/+wJxiwFrRSP54AopDxIv4JRp/rGwcgk/lZS/0Clw8jYA=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.2.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.5.tgz",
-      "integrity": "sha512-VBjVbmqEzGiOTBq4+wpeVXt/KgknnGB6ahvC/AxiIGnN93/RCSyXhFRI4uSfftM2Ba3w7ZO7076bfKasZsA0fw==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.0.tgz",
+      "integrity": "sha512-jVdq1qYTNDjUtulnE8/hkPv0pHILV4jMg5La99iaY/FFm20WxVnsAZtbNnMvlPbf8dc010oO304SX9yXbg5PAw==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -16468,12 +16439,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.2.4.tgz",
-      "integrity": "sha512-r3keSLY1Z+rN+ASN8nmWwZ+AsMl6IrPGRWgbQhKHcop4/fk1hJGxE9Xf/mYMkV07+1Q/catchw25lu525HFy5Q==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.0.tgz",
+      "integrity": "sha512-guHSkNyKnTBB8HU35COgAMeMV0E026BiYRYvyEVVaTOeFcnU3i1EI8/Da0Rl7H3Sgua5FEvoA0vYd2s8kdIUXg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.2.4",
+        "@next/eslint-plugin-next": "12.3.0",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -16482,31 +16453,6 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "^4.5.0"
-      },
-      "dependencies": {
-        "@next/eslint-plugin-next": {
-          "version": "12.2.4",
-          "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.2.4.tgz",
-          "integrity": "sha512-ChDkUIkJeYWKRx+FdF+EhUgvKtK1wF+Xew4Os7ef3iAjMch5GGBiezw2zGXTa/C0E6potz4j11EpX89mngffug==",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.7"
-          }
-        },
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "eslint-config-prettier": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,7 +50,7 @@
         "autoprefixer": "^10.4.4",
         "cross-env": "^7.0.3",
         "eslint": "^8.21.0",
-        "eslint-config-next": "12.2.4",
+        "eslint-config-next": "^12.2.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-import-resolver-typescript": "^2.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "autoprefixer": "^10.4.4",
     "cross-env": "^7.0.3",
     "eslint": "^8.21.0",
-    "eslint-config-next": "^12.2.4",
+    "eslint-config-next": "^12.3.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-import-resolver-typescript": "^2.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "autoprefixer": "^10.4.4",
     "cross-env": "^7.0.3",
     "eslint": "^8.21.0",
-    "eslint-config-next": "12.2.4",
+    "eslint-config-next": "^12.2.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-import-resolver-typescript": "^2.5.0",

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -50,6 +50,7 @@ export type SyncStatusDataT = {
 export type RepoSyncDataType = {
   data: {
     id: string
+    type: string
     title: string
     brief: string
   }
@@ -61,6 +62,7 @@ export type RepoSyncDataType = {
 }
 
 export type RepoSyncData = {
+  id: string
   name: string
   type: RepoType
   syncs?: Array<RepoSyncDataType>

--- a/ui/src/__mocks__/constants.mock.ts
+++ b/ui/src/__mocks__/constants.mock.ts
@@ -6,7 +6,9 @@ export enum DynamicValues {
   validPAT = 'ghp_cJYwtBb8DbdXNYAw3wegVcTFDYJQhu0QpmCQ',
   invalidPAT = 'gho_cJYwtBb8DbdXNYAw3wegVcTFDYJQhpmCQ',
   autoImportUser = 'gdcanonn',
+  repoId = '75f18931-8cd4-49a4-913a-5968c1bac680',
   syncTypeId = '220885be-fdaa-426d-8ca4-a4e85db9f94b',
+  newSyncTypeId = 'f12d3697-bd34-4b86-93d3-ee70af0c49a4',
   syncTypeGitCommitStatId = '0fd4b41f-f2fd-4313-bb05-21a24daf9710',
   syncTypeGitFilesId = '101890be-162a-4cb8-b103-22ea924cbdca'
 }

--- a/ui/src/__mocks__/syncs.mock.ts
+++ b/ui/src/__mocks__/syncs.mock.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
-import { GetRepoSyncsQuery, SyncMutation } from 'src/api-logic/graphql/generated/schema'
-import SYNC_NOW from 'src/api-logic/graphql/mutations/syncs'
+import { AddSyncTypeMutation, GetRepoSyncsQuery, SyncMutation } from 'src/api-logic/graphql/generated/schema'
+import { ADD_SYNC_TYPE, SYNC_NOW } from 'src/api-logic/graphql/mutations/syncs'
 import GET_REPO_SYNCS from 'src/api-logic/graphql/queries/get-repo-syncs.query'
 import { DynamicValues } from './constants.mock'
 
@@ -97,9 +97,62 @@ const queueArray = (runningSync: boolean) => ([
   }
 ])
 
+const syncsTypesArray = [
+  {
+    type: 'GIT_COMMITS',
+    description: 'Retrieves the commit history of a repo',
+    shortName: 'Git Commits'
+  },
+  {
+    type: 'GIT_COMMIT_STATS',
+    description: 'Retrieves commit stats for a repo',
+    shortName: 'Git Commit Stats'
+  },
+  {
+    type: 'GIT_FILES',
+    description: 'Retrieves files (content and paths) of a git repo',
+    shortName: 'Git Files'
+  },
+  {
+    type: 'GITHUB_PR_COMMITS',
+    description: 'Retrieves commits for all pull requests in a GitHub repo',
+    shortName: 'GitHub PR Commits'
+  },
+  {
+    type: 'GITHUB_PR_REVIEWS',
+    description: 'Retrieves the reviews of all pull requests in a GitHub repo',
+    shortName: 'GitHub PR Reviews'
+  },
+  {
+    type: 'GITHUB_REPO_ISSUES',
+    description: 'Retrieves all the issues of a GitHub repo',
+    shortName: 'GitHub Repo Issues'
+  },
+  {
+    type: 'GITHUB_REPO_METADATA',
+    description: 'Retrieves metadata about a GitHub repo',
+    shortName: 'GitHub Repo Metadata'
+  },
+  {
+    type: 'GITHUB_REPO_PRS',
+    description: 'Retrieves all the pull requests of a GitHub repo',
+    shortName: 'GitHub Repo Pull Requests'
+  },
+  {
+    type: 'GITHUB_REPO_STARS',
+    description: 'Retrieves all stargazers of a GitHub repo',
+    shortName: 'GitHub Repo Stars'
+  },
+  {
+    type: 'GIT_REFS',
+    description: 'Retrieves all the refs of a git repo',
+    shortName: 'Git Refs'
+  }
+]
+
 export const mockSyncsTypesData = (runningSync: boolean): GetRepoSyncsQuery => ({
   repo: {
-    id: faker.datatype.uuid(),
+    id: DynamicValues.repoId,
     repo: 'https://github.com/mergestat/mergestat',
     isGithub: true,
     repoSyncs: {
@@ -107,9 +160,6 @@ export const mockSyncsTypesData = (runningSync: boolean): GetRepoSyncsQuery => (
         {
           id: DynamicValues.syncTypeGitCommitStatId,
           syncType: 'GIT_COMMIT_STATS',
-          repoSyncTypeBySyncType: {
-            description: 'Retrieves commit stats for a repo'
-          },
           repoSyncQueues: {
             nodes: queueArray(false)
           }
@@ -117,19 +167,19 @@ export const mockSyncsTypesData = (runningSync: boolean): GetRepoSyncsQuery => (
         {
           id: DynamicValues.syncTypeGitFilesId,
           syncType: 'GIT_FILES',
-          repoSyncTypeBySyncType: {
-            description: 'Retrieves files (content and paths) of a git repo'
-          },
           repoSyncQueues: {
             nodes: queueArray(runningSync)
           }
         }
       ],
     },
+  },
+  repoSyncTypes: {
+    nodes: syncsTypesArray
   }
-}
-)
+})
 
+// Apollo Mock: Sync Types
 export const apolloMockSyncsTypesData = {
   request: {
     query: GET_REPO_SYNCS,
@@ -140,6 +190,7 @@ export const apolloMockSyncsTypesData = {
   }
 }
 
+// Apollo Mock: Sync Types with a sync running
 export const apolloMockSyncsTypesRunningData = {
   request: {
     query: GET_REPO_SYNCS,
@@ -150,6 +201,7 @@ export const apolloMockSyncsTypesRunningData = {
   }
 }
 
+// Apollo Mock: Sync now
 export const mockSyncNow: SyncMutation = {
   createRepoSyncQueue: {
     repoSyncQueue: {
@@ -167,5 +219,46 @@ export const apolloMockSyncNow = {
   },
   result: {
     data: mockSyncNow
+  }
+}
+
+// Apollo Mock: Sync now after a sync type addition
+export const mockNextSyncNow: SyncMutation = {
+  createRepoSyncQueue: {
+    repoSyncQueue: {
+      id: faker.random.numeric(4),
+      status: 'QUEUED',
+      createdAt: faker.date.recent(),
+    },
+  }
+}
+
+export const apolloMockNextSyncNow = {
+  request: {
+    query: SYNC_NOW,
+    variables: { syncId: DynamicValues.newSyncTypeId }
+  },
+  result: {
+    data: mockNextSyncNow
+  }
+}
+
+// Apollo Mock: Add sync type
+export const mockAddSyncType: AddSyncTypeMutation = {
+  createRepoSync: {
+    repoSync: {
+      id: DynamicValues.newSyncTypeId,
+      syncType: 'GIT_COMMITS',
+    },
+  }
+}
+
+export const apolloMockAddSyncType = {
+  request: {
+    query: ADD_SYNC_TYPE,
+    variables: { repoId: DynamicValues.repoId, syncType: 'GIT_COMMITS' }
+  },
+  result: {
+    data: mockAddSyncType
   }
 }

--- a/ui/src/__tests__/syncs.test.tsx
+++ b/ui/src/__tests__/syncs.test.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import RepoDetailsPage from 'src/pages/repos/[repository]'
 import { TEST_IDS } from 'src/utils/constants'
 import { DynamicValues } from 'src/__mocks__/constants.mock'
-import { apolloMockSyncNow, apolloMockSyncsTypesData, apolloMockSyncsTypesRunningData } from 'src/__mocks__/syncs.mock'
+import { apolloMockAddSyncType, apolloMockNextSyncNow, apolloMockSyncNow, apolloMockSyncsTypesData, apolloMockSyncsTypesRunningData } from 'src/__mocks__/syncs.mock'
 
 jest.mock('next/router', () => ({
   __esModule: true,
@@ -29,15 +29,42 @@ describe('GraphQL queries: (Syncs Types)', () => {
       </MockedProvider>
     )
 
-    // Checks syncs types table has 2 rows
+    // Checks syncs types table has 10 rows
     await waitFor(() => {
       const rows = screen.getAllByTestId(TEST_IDS.syncsTypesRow)
-      expect(rows.length).toBe(2)
+      expect(rows.length).toBe(10)
     })
 
     // Get 'Sync Now' button
     const buttons = screen.getAllByTestId(TEST_IDS.syncsTypesSyncNowButton)
-    fireEvent.click(buttons[1] as HTMLButtonElement)
+    fireEvent.click(buttons[2] as HTMLButtonElement)
+
+    // Checks if 'Git Files' is syncing
+    await waitFor(() => {
+      const element = screen.getByText('Syncing...')
+      expect(element as HTMLSpanElement).toBeInTheDocument()
+    })
+  })
+
+  it('calling useMutation(): first time hitting sync now', async () => {
+    const mockRouter = { query: { repository: DynamicValues.syncTypeId } };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    render(
+      <MockedProvider mocks={[apolloMockSyncsTypesData, apolloMockAddSyncType, apolloMockNextSyncNow, apolloMockSyncsTypesRunningData]} addTypename={false}>
+        <RepoDetailsPage />
+      </MockedProvider>
+    )
+
+    // Checks syncs types table has 10 rows
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(TEST_IDS.syncsTypesRow)
+      expect(rows.length).toBe(10)
+    })
+
+    // Get 'Sync Now' button
+    const buttons = screen.getAllByTestId(TEST_IDS.syncsTypesSyncNowButton)
+    fireEvent.click(buttons[0] as HTMLButtonElement)
 
     // Checks if 'Git Files' is syncing
     await waitFor(() => {

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -8584,6 +8584,14 @@ export type SyncMutationVariables = Exact<{
 
 export type SyncMutation = { createRepoSyncQueue?: { repoSyncQueue?: { id: any, status: string, createdAt: any } | null } | null };
 
+export type AddSyncTypeMutationVariables = Exact<{
+  repoId: Scalars['UUID'];
+  syncType: Scalars['String'];
+}>;
+
+
+export type AddSyncTypeMutation = { createRepoSync?: { repoSync?: { id: any, syncType: string } | null } | null };
+
 export type GetRepoImportsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -8594,7 +8602,7 @@ export type GetRepoSyncsQueryVariables = Exact<{
 }>;
 
 
-export type GetRepoSyncsQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { description?: string | null } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, startedAt?: any | null, doneAt?: any | null }> } }> } } | null };
+export type GetRepoSyncsQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncQueues: { nodes: Array<{ id: any, status: string, startedAt?: any | null, doneAt?: any | null }> } }> } } | null, repoSyncTypes?: { nodes: Array<{ type: string, description?: string | null, shortName: string }> } | null };
 
 export type GetReposQueryVariables = Exact<{
   search: Scalars['String'];

--- a/ui/src/api-logic/graphql/mutations/syncs.ts
+++ b/ui/src/api-logic/graphql/mutations/syncs.ts
@@ -13,4 +13,16 @@ const SYNC_NOW = gql`
     }
   }
 `
-export default SYNC_NOW
+
+const ADD_SYNC_TYPE = gql`
+  mutation addSyncType($repoId: UUID!, $syncType: String!) {
+    createRepoSync(input: {repoSync: {repoId: $repoId, syncType: $syncType}}) {
+      repoSync {
+        id
+        syncType
+      }
+    }
+  }
+`
+
+export { SYNC_NOW, ADD_SYNC_TYPE }

--- a/ui/src/api-logic/graphql/queries/get-repo-syncs.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-repo-syncs.query.ts
@@ -10,9 +10,6 @@ const GET_REPO_SYNCS = gql`
         nodes {
           id
           syncType
-          repoSyncTypeBySyncType {
-            description
-          }
           repoSyncQueues(first: 15, orderBy: CREATED_AT_DESC) {
             nodes {
               id
@@ -22,6 +19,13 @@ const GET_REPO_SYNCS = gql`
             }
           }
         }
+      }
+    }
+    repoSyncTypes {
+      nodes {
+        type
+        description
+        shortName
       }
     }
   }

--- a/ui/src/components/RepoSyncIcon.tsx
+++ b/ui/src/components/RepoSyncIcon.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@mergestat/blocks'
-import { CircleCheckFilledIcon, CircleErrorFilledIcon, CircleInformationFilledIcon, ClockIcon } from '@mergestat/icons'
+import { CircleCheckFilledIcon, CircleErrorFilledIcon, CircleInformationFilledIcon, ClockIcon, MinusIcon } from '@mergestat/icons'
 import cx from 'classnames'
 import type { RepoSyncStateT } from 'src/@types'
 import { SYNC_STATUS } from 'src/utils/constants'
@@ -22,6 +22,6 @@ export const RepoSyncIcon = ({ type, className = '' }: RepoSyncIconPropsT) => {
     case SYNC_STATUS.running:
       return <Spinner size="sm" className={className} />
     default:
-      return <></>
+      return <MinusIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
   }
 }

--- a/ui/src/views/hooks/useSyncNow.ts
+++ b/ui/src/views/hooks/useSyncNow.ts
@@ -1,5 +1,6 @@
 import { ApolloError, useMutation } from '@apollo/client'
-import SYNC_NOW from 'src/api-logic/graphql/mutations/syncs'
+import { AddSyncTypeMutation } from 'src/api-logic/graphql/generated/schema'
+import { ADD_SYNC_TYPE, SYNC_NOW } from 'src/api-logic/graphql/mutations/syncs'
 import { showErrorAlert } from 'src/utils/alerts'
 
 const useSyncNow = (refetch: () => void) => {
@@ -11,7 +12,21 @@ const useSyncNow = (refetch: () => void) => {
       refetch()
     }
   })
-  return { syncNow }
+
+  const [addSyncType] = useMutation(ADD_SYNC_TYPE, {
+    onError: (error: ApolloError) => {
+      showErrorAlert(error.message)
+    },
+    onCompleted: (data: AddSyncTypeMutation) => {
+      syncNow({
+        variables: {
+          syncId: data.createRepoSync?.repoSync?.id
+        }
+      })
+    }
+  })
+
+  return { syncNow, addSyncType }
 }
 
 export default useSyncNow

--- a/ui/src/views/repository-data/components/sync-types-table/components/repository-data.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/components/repository-data.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
 import cx from 'classnames'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import React from 'react'
 
 export type RepositoryDataProps = {
   id: string
@@ -15,11 +15,16 @@ export const RepositoryData: React.FC<RepositoryDataProps> = (props) => {
 
   return (
     <div className={cx('py-5 flex flex-col justify-center items-start h-full', { 'bg-gray-50': props.disabled })}>
-      <Link href={`/repos/${repository}/${props.id}`}>
-        <h4 className="font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600">
+      {props.id
+        ? <Link href={`/repos/${repository}/${props.id}`}>
+          <h4 className="font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600">
+            {props.title}
+          </h4>
+        </Link>
+        : <h4 className="font-medium mb-0.5 text-semantic-text">
           {props.title}
         </h4>
-      </Link>
+      }
 
       <p className="text-sm text-semantic-mutedText">
         {props.brief}

--- a/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-now.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-now.tsx
@@ -7,13 +7,15 @@ import useSyncNow from 'src/views/hooks/useSyncNow'
 import useSyncs from 'src/views/hooks/useSyncs'
 
 export type RepositorySyncNowProps = {
-  id: string
+  repoId: string
+  syncType: string
+  syncTypeId: string
   syncStatus: RepoSyncStateT
 }
 
-export const RepositorySyncNow: React.FC<RepositorySyncNowProps> = ({ id, syncStatus }) => {
+export const RepositorySyncNow: React.FC<RepositorySyncNowProps> = ({ repoId, syncType, syncTypeId, syncStatus }) => {
   const { refetch } = useSyncs()
-  const { syncNow } = useSyncNow(refetch)
+  const { syncNow, addSyncType } = useSyncNow(refetch)
 
   if (syncStatus === SYNC_STATUS.disabled) return <div className='h-full bg-gray-50' />
 
@@ -31,11 +33,9 @@ export const RepositorySyncNow: React.FC<RepositorySyncNowProps> = ({ id, syncSt
       }
       size="small"
       onClick={() => {
-        syncNow({
-          variables: {
-            syncId: id
-          }
-        })
+        syncTypeId
+          ? syncNow({ variables: { syncId: syncTypeId } })
+          : addSyncType({ variables: { repoId, syncType } })
       }}
     >
       {syncStatus === SYNC_STATUS.running ? 'Syncing...' : 'Sync Now'}

--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -1,6 +1,6 @@
 import { Panel } from '@mergestat/blocks'
 import cx from 'classnames'
-import React, { PropsWithChildren } from 'react'
+import React, { PropsWithChildren, useId } from 'react'
 import { RepoSyncDataType } from 'src/@types'
 import { RelativeTimeField } from 'src/components/Fields/relative-time-field'
 import { RepoSyncIcon } from 'src/components/RepoSyncIcon'
@@ -8,10 +8,13 @@ import { SYNC_STATUS, TEST_IDS } from 'src/utils/constants'
 import { RepositoryData, RepositorySyncNow, RepositorySyncStatus, RepositoryTableRowOptions } from './components'
 
 type SycnTypesTableProps = PropsWithChildren<{
+  repoId: string
   data: Array<RepoSyncDataType>
 }>
 
-export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ data }: SycnTypesTableProps) => {
+export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: SycnTypesTableProps) => {
+  const id = useId()
+
   return (
     <div className="rounded-md shadow-sm">
       <Panel className="rounded-md w-full shadow-sm">
@@ -51,8 +54,8 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ data }: SycnType
                 </thead>
 
                 <tbody className='bg-white'>
-                  {data.map((sync) => (
-                    <tr data-testid={TEST_IDS.syncsTypesRow} key={sync.data.id}>
+                  {data.map((sync, index) => (
+                    <tr data-testid={TEST_IDS.syncsTypesRow} key={sync.data.id ?? `${id}-${index}`}>
                       <td className="w-12 h-20 p-0">
                         <div className={cx('h-full px-6 flex justify-center', { 'bg-gray-50': sync.status.syncState === SYNC_STATUS.disabled })}>
                           <RepoSyncIcon type={sync.status.syncState} className="my-auto" />
@@ -80,7 +83,12 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ data }: SycnType
                       </td>
 
                       <td className='h-20 p-0'>
-                        <RepositorySyncNow id={sync.data.id} syncStatus={sync.status.syncState} />
+                        <RepositorySyncNow
+                          repoId={repoId}
+                          syncType={sync.data.type}
+                          syncTypeId={sync.data.id}
+                          syncStatus={sync.status.syncState}
+                        />
                       </td>
 
                       <td className='px-6 w-4'>

--- a/ui/src/views/repository-data/index.tsx
+++ b/ui/src/views/repository-data/index.tsx
@@ -21,7 +21,7 @@ const RepoDataView = ({ data }: RepoDataViewProps) => {
         </Tabs.List>
         <Tabs.Panels className="p-8 flex-1 overflow-auto">
           <Tabs.Panel>
-            <SycnTypesTable data={data?.syncs || []} />
+            <SycnTypesTable repoId={data?.id || ''} data={data?.syncs || []} />
           </Tabs.Panel>
           <Tabs.Panel>
             <RepoSettings />


### PR DESCRIPTION
Listing all available sync types for any repo. (Resolves #163)

- Adding new mutation to record a new `sync type` for a repo
- Showing `short name` in sync types
- Disabling going to `/repos/${repository}/${syncTypeId}` when it is first time to sync
- Unit testing

![list-sync-types](https://user-images.githubusercontent.com/109089565/189453640-8c29240e-ceb3-413f-b836-cfce05116562.png)
