### PR TITLE
fix: `npm i --save-dev eslint-config-next`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,7 +50,7 @@
         "autoprefixer": "^10.4.4",
         "cross-env": "^7.0.3",
         "eslint": "^8.21.0",
-        "eslint-config-next": "12.2.4",
+        "eslint-config-next": "^12.2.4",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-import-resolver-typescript": "^2.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "autoprefixer": "^10.4.4",
     "cross-env": "^7.0.3",
     "eslint": "^8.21.0",
-    "eslint-config-next": "12.2.4",
+    "eslint-config-next": "^12.2.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-import-resolver-typescript": "^2.5.0",


### PR DESCRIPTION
updates `eslint-config-next` and seems to address the lint config issue?