### PR TITLE
feat: implement basic `GIT_BLAME` syncer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/share/pkgconfig/libgit2/lib/pkgconfig/
 
 FROM debian:buster-slim
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ca-certificates curl postgresql-client && \
+    ca-certificates curl postgresql-client git && \
     rm -rf /var/lib/apt/lists/*
 
 # copy over migrations

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/jackc/pgconn v1.11.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/libgit2/git2go/v33 v33.0.9
+	github.com/mergestat/gitutils v0.0.0-20220914171827-3d3e275684fb
 	github.com/prometheus/client_golang v1.12.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00

--- a/go.sum
+++ b/go.sum
@@ -895,6 +895,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/mergestat/gitutils v0.0.0-20220914171827-3d3e275684fb h1:Z7YYU8oKtqQMUjGGGmbYk2lDKG5NYig6J5SoUlPm+N0=
+github.com/mergestat/gitutils v0.0.0-20220914171827-3d3e275684fb/go.mod h1:5d4bkPk7xkGw9u9uyz9g0Q38gwOoD4Q1ocY5/CFl9J8=
 github.com/mergestat/mergestat v0.5.8 h1:ZPvt07TrSoV8WpkxuvUE9iaw+wfeTI5S970y1U9Qfgo=
 github.com/mergestat/mergestat v0.5.8/go.mod h1:bgr9yZt5uhqc4UCh60I2bEAaL6jIPh2oLsyQf5Axnzw=
 github.com/mergestat/timediff v0.0.3 h1:ucCNh4/ZrTPjFZ081PccNbhx9spymCJkFxSzgVuPU+Y=

--- a/internal/syncer/git_blame.go
+++ b/internal/syncer/git_blame.go
@@ -1,0 +1,178 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v4"
+	libgit2 "github.com/libgit2/git2go/v33"
+	"github.com/mergestat/fuse/internal/db"
+	"github.com/mergestat/gitutils/blame"
+	"github.com/mergestat/gitutils/lstree"
+	uuid "github.com/satori/go.uuid"
+)
+
+func (w *worker) sendBatchBlameLines(ctx context.Context, tx pgx.Tx, j *db.DequeueSyncJobRow, batch []*blameLine) error {
+	inputs := make([][]interface{}, 0, len(batch))
+	for _, l := range batch {
+		var repoID uuid.UUID
+		var err error
+		if repoID, err = uuid.FromString(j.RepoID.String()); err != nil {
+			return fmt.Errorf("uuid: %w", err)
+		}
+
+		// sanitize the line of null chars, similar to what's done in GIT_FILES syncer
+		var line interface{}
+		if l.Line != nil && utf8.ValidString(*l.Line) {
+			line = strings.ReplaceAll(*l.Line, "\u0000", "")
+		} else {
+			line = nil
+		}
+
+		input := []interface{}{repoID, l.AuthorEmail, l.AuthorName, l.AuthorWhen, l.CommitHash, l.LineNo, line, l.Path}
+		inputs = append(inputs, input)
+	}
+
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"git_blame"}, []string{"repo_id", "author_email", "author_name", "author_when", "commit_hash", "line_no", "line", "path"}, pgx.CopyFromRows(inputs)); err != nil {
+		return fmt.Errorf("tx copy from: %w", err)
+	}
+	return nil
+}
+
+type blameLine struct {
+	AuthorEmail *string
+	AuthorName  *string
+	AuthorWhen  *time.Time
+	CommitHash  *string
+	LineNo      *int
+	Line        *string
+	Path        *string
+}
+
+func (w *worker) handleGitBlame(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpPath); err != nil {
+			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
+		}
+	}()
+
+	var ghToken string
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	var repo *libgit2.Repository
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, false); err != nil {
+		return fmt.Errorf("git clone: %w", err)
+	}
+	defer repo.Free()
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{
+		{
+			Type:            SyncLogTypeInfo,
+			RepoSyncQueueID: j.ID,
+			Message:         "starting to execute git blame query",
+		},
+	}); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	blamedLines := make([]*blameLine, 0)
+
+	iter, err := lstree.Exec(ctx, tmpPath, "HEAD", lstree.WithRecurse(true))
+	if err != nil {
+		return fmt.Errorf("git ls-tree error: %w", err)
+	}
+
+	var objects []*lstree.Object
+	for {
+		if o, err := iter.Next(); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			} else {
+				log.Fatal(err)
+			}
+		} else {
+			objects = append(objects, o)
+		}
+	}
+
+	for _, o := range objects {
+		if o.Type != "blob" {
+			continue
+		}
+		res, err := blame.Exec(ctx, tmpPath, o.Path)
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				w.logger.Err(err).Str("repoPath", tmpPath).Str("filePath", o.Path).Msgf("error blaming file in repo: %s, %v: %s", tmpPath, err, exitErr.Stderr)
+			} else {
+				w.logger.Err(err).Msgf("error blaming file in repo: %s, %v", tmpPath, err)
+			}
+			continue
+		}
+
+		for lineIdx, blame := range res {
+			lineNo := lineIdx + 1
+			blamedLines = append(blamedLines, &blameLine{
+				AuthorEmail: &blame.Author.Email,
+				AuthorName:  &blame.Author.Name,
+				AuthorWhen:  &blame.Author.When,
+				CommitHash:  &blame.SHA,
+				LineNo:      &lineNo,
+				Line:        &blame.Line,
+				Path:        &o.Path,
+			})
+		}
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, "DELETE FROM git_blame WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if err := w.sendBatchBlameLines(ctx, tx, j, blamedLines); err != nil {
+		return fmt.Errorf("send batch blamed lines: %w", err)
+	}
+
+	l.Info().Msgf("sent batch of %d blamed lines", len(blamedLines))
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{
+		{
+			Type:            SyncLogTypeInfo,
+			RepoSyncQueueID: j.ID,
+			Message:         "finished",
+		},
+	}); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jackc/pgx/v4"
@@ -44,7 +43,7 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 	l := w.loggerForJob(j)
 
 	// TODO(patrickdevivo) uplift the following os.Getenv call to one place, pass value down as a param
-	tmpPath, err := ioutil.TempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
 	if err != nil {
 		return err
 	}
@@ -60,7 +59,7 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jackc/pgx/v4"
@@ -98,7 +97,7 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	l := w.loggerForJob(j)
 
 	// TODO(patrickdevivo) uplift the following os.Getenv call to one place, pass value down as a param
-	tmpPath, err := ioutil.TempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
 	if err != nil {
 		return err
 	}
@@ -114,7 +113,7 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_files.go
+++ b/internal/syncer/git_files.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"unicode/utf8"
@@ -56,7 +55,7 @@ FROM files(?);
 func (w *worker) handleGitFiles(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
-	tmpPath, err := ioutil.TempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
 	}
@@ -72,7 +71,7 @@ func (w *worker) handleGitFiles(ctx context.Context, j *db.DequeueSyncJobRow) er
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_refs.go
+++ b/internal/syncer/git_refs.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jackc/pgx/v4"
@@ -80,7 +79,7 @@ func (w *worker) handleGitRefs(ctx context.Context, j *db.DequeueSyncJobRow) err
 	l := w.loggerForJob(j)
 
 	// TODO(patrickdevivo) uplift the following os.Getenv call to one place, pass value down as a param
-	tmpPath, err := ioutil.TempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
 	if err != nil {
 		return err
 	}
@@ -96,7 +95,7 @@ func (w *worker) handleGitRefs(ctx context.Context, j *db.DequeueSyncJobRow) err
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath); err != nil {
+	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/migrations/20220911143334_git_blame_sync.down.sql
+++ b/migrations/20220911143334_git_blame_sync.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE git_blamed_lines;
+
+COMMIT;

--- a/migrations/20220911143334_git_blame_sync.up.sql
+++ b/migrations/20220911143334_git_blame_sync.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('GIT_BLAME', 'Retrieves the git blame of all lines in all files of a git repository', 'Git Blame') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS git_blame (
+    repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+    author_email text,
+    author_name text,
+    author_when timestamp with time zone,
+    commit_hash text,
+    line_no integer,
+    line text,
+    path text,
+    _mergestat_synced_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT git_blame_pkey PRIMARY KEY (repo_id, path, line_no)
+);
+
+COMMIT;


### PR DESCRIPTION
- Implement a `GIT_BLAME` sync that inserts a row for every line of code (!) in a repo, including it's basic blame info. This approach shells out to the `git` CLI, which is much more performant than an implementation using `libgit2` (in our initial tests)
- Some minor updates in other syncers to remove use of deprecated funcs

Addresses #151 