### PR TITLE
fix: reference to `meta` step in GitHub workflow

### DIFF
--- a/.github/workflows/publish-graphql-docker.yaml
+++ b/.github/workflows/publish-graphql-docker.yaml
@@ -62,7 +62,7 @@ jobs:
         name: Sign the images with GitHub OIDC Token
         run: cosign sign ${TAGS}
         env:
-          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          TAGS: ${{ steps.meta.outputs.tags }}
           COSIGN_EXPERIMENTAL: true
         # Only sign the container if this is a release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/publish-ui-docker.yaml
+++ b/.github/workflows/publish-ui-docker.yaml
@@ -62,7 +62,7 @@ jobs:
         name: Sign the images with GitHub OIDC Token
         run: cosign sign ${TAGS}
         env:
-          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          TAGS: ${{ steps.meta.outputs.tags }}
           COSIGN_EXPERIMENTAL: true
         # Only sign the container if this is a release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/publish-worker-docker.yaml
+++ b/.github/workflows/publish-worker-docker.yaml
@@ -62,7 +62,7 @@ jobs:
         name: Sign the images with GitHub OIDC Token
         run: cosign sign ${TAGS}
         env:
-          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          TAGS: ${{ steps.meta.outputs.tags }}
           COSIGN_EXPERIMENTAL: true
         # Only sign the container if this is a release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
this should address the failing `cosign` run