### PR TITLE
feat(tooltip-status): Adding tooltips to status icons

### DIFF
--- a/ui/src/components/RepoSyncIcon.tsx
+++ b/ui/src/components/RepoSyncIcon.tsx
@@ -23,26 +23,32 @@ const WithTooltip: React.FC<WithTooltipPropsT> = ({ status, icon }: WithTooltipP
 }
 
 export const RepoSyncIcon = ({ type, className = '' }: RepoSyncIconPropsT) => {
-  let icon
+  let icon, text
   switch (type) {
     case SYNC_STATUS.disabled:
+      text = 'Sync is disabled'
       icon = <CircleInformationFilledIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.succeeded:
+      text = 'Last sync was successful'
       icon = <CircleCheckFilledIcon className={cx('t-icon text-semantic-success', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.failed:
+      text = 'Last sync had an error'
       icon = <CircleErrorFilledIcon className={cx('t-icon text-semantic-danger', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.queued:
+      text = 'Sync is queued to run'
       icon = <ClockIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.running:
+      text = 'Sync is currently running'
       icon = <Spinner size="sm" className={className} />
       break
     default:
+      text = 'No sync history'
       icon = <MinusIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
       break
   }
-  return <WithTooltip status={`${type.charAt(0).toUpperCase()}${type.slice(1)}`} icon={icon} />
+  return <WithTooltip status={text} icon={icon} />
 }

--- a/ui/src/components/RepoSyncIcon.tsx
+++ b/ui/src/components/RepoSyncIcon.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@mergestat/blocks'
+import { Spinner, Tooltip } from '@mergestat/blocks'
 import { CircleCheckFilledIcon, CircleErrorFilledIcon, CircleInformationFilledIcon, ClockIcon, MinusIcon } from '@mergestat/icons'
 import cx from 'classnames'
 import type { RepoSyncStateT } from 'src/@types'
@@ -9,19 +9,40 @@ type RepoSyncIconPropsT = {
   className?: string
 }
 
+type WithTooltipPropsT = {
+  status: string
+  icon: JSX.Element
+}
+
+const WithTooltip: React.FC<WithTooltipPropsT> = ({ status, icon }: WithTooltipPropsT) => {
+  return (
+    <Tooltip content={status} placement='bottom'>
+      {icon}
+    </Tooltip>
+  )
+}
+
 export const RepoSyncIcon = ({ type, className = '' }: RepoSyncIconPropsT) => {
+  let icon
   switch (type) {
     case SYNC_STATUS.disabled:
-      return <CircleInformationFilledIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <CircleInformationFilledIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      break
     case SYNC_STATUS.succeeded:
-      return <CircleCheckFilledIcon className={cx('t-icon text-semantic-success', { [className]: className !== '' })} />
+      icon = <CircleCheckFilledIcon className={cx('t-icon text-semantic-success', { [className]: className !== '' })} />
+      break
     case SYNC_STATUS.failed:
-      return <CircleErrorFilledIcon className={cx('t-icon text-semantic-danger', { [className]: className !== '' })} />
+      icon = <CircleErrorFilledIcon className={cx('t-icon text-semantic-danger', { [className]: className !== '' })} />
+      break
     case SYNC_STATUS.queued:
-      return <ClockIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <ClockIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      break
     case SYNC_STATUS.running:
-      return <Spinner size="sm" className={className} />
+      icon = <Spinner size="sm" className={className} />
+      break
     default:
-      return <MinusIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <MinusIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      break
   }
+  return <WithTooltip status={`${type.charAt(0).toUpperCase()}${type.slice(1)}`} icon={icon} />
 }

--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -57,7 +57,7 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: 
                   {data.map((sync, index) => (
                     <tr data-testid={TEST_IDS.syncsTypesRow} key={sync.data.id ?? `${id}-${index}`}>
                       <td className="w-12 h-20 p-0">
-                        <div className={cx('h-full px-6 flex justify-center', { 'bg-gray-50': sync.status.syncState === SYNC_STATUS.disabled })}>
+                        <div className={cx('h-full px-6 flex justify-center items-center', { 'bg-gray-50': sync.status.syncState === SYNC_STATUS.disabled })}>
                           <RepoSyncIcon type={sync.status.syncState} className="my-auto" />
                         </div>
                       </td>


### PR DESCRIPTION
Adding tooltips to status icons. (Resolves #116)

<img width="662" alt="tooltip-icon" src="https://user-images.githubusercontent.com/109089565/190693569-9faaaf05-f028-40f5-8170-b9d951047873.png">
