### PR TITLE
feat: implement simple way to show DB creds (from ENV)

### DIFF
--- a/docker-compose.ui-dev.yaml
+++ b/docker-compose.ui-dev.yaml
@@ -30,3 +30,7 @@ services:
       - "--legacy-relations=omit"
     environment:
       FUSE_SECRET: password
+      DISPLAY_PG_HOSTNAME: localhost
+      DISPLAY_PG_PORT: 5432
+      DISPLAY_PG_DATABASE: postgres
+      DISPLAY_PG_USER: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,6 +57,10 @@ services:
       - "--legacy-relations=omit"
     environment:
       FUSE_SECRET: password
+      DISPLAY_PG_HOSTNAME: localhost
+      DISPLAY_PG_PORT: 5432
+      DISPLAY_PG_DATABASE: postgres
+      DISPLAY_PG_USER: postgres
 
   ui:
     restart: always

--- a/graphql/service-credentials/index.js
+++ b/graphql/service-credentials/index.js
@@ -12,10 +12,22 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const graphile_utils_1 = require("graphile-utils");
 // FUSE_SECRET is used to encrypt credentials before they go into the DB
 const { FUSE_SECRET } = process.env;
+// If these env vars are set (DISPLAY_PG_*) they will be accessible via the databaseConnection Query
+// They are meant to be set by an operator for display in the /connect page of the UI
+const { DISPLAY_PG_HOSTNAME, DISPLAY_PG_PORT, DISPLAY_PG_DATABASE, DISPLAY_PG_USER } = process.env;
 module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
     typeDefs: (0, graphile_utils_1.gql) `
     extend type Mutation {
       replaceGitHubPAT(pat: String!): Boolean
+    }
+    extend type Query {
+      databaseConnection: DisplayDatabaseConnection
+    }
+    type DisplayDatabaseConnection {
+      host: String
+      port: Int
+      database: String
+      user: String
     }
   `,
     resolvers: {
@@ -42,5 +54,17 @@ module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
                 });
             },
         },
+        Query: {
+            databaseConnection(_parent, _args, _context, _info) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    return {
+                        host: DISPLAY_PG_HOSTNAME || null,
+                        port: DISPLAY_PG_PORT || null,
+                        database: DISPLAY_PG_DATABASE || null,
+                        user: DISPLAY_PG_USER || null,
+                    };
+                });
+            }
+        }
     },
 });

--- a/graphql/service-credentials/index.ts
+++ b/graphql/service-credentials/index.ts
@@ -4,6 +4,10 @@ import { Client } from 'pg'
 // FUSE_SECRET is used to encrypt credentials before they go into the DB
 const { FUSE_SECRET } = process.env
 
+// If these env vars are set (DISPLAY_PG_*) they will be accessible via the databaseConnection Query
+// They are meant to be set by an operator for display in the /connect page of the UI
+const { DISPLAY_PG_HOSTNAME, DISPLAY_PG_PORT, DISPLAY_PG_DATABASE, DISPLAY_PG_USER } = process.env
+
 type ReplaceGitHubPATInput = {
   pat: string
 }
@@ -12,6 +16,15 @@ module.exports = makeExtendSchemaPlugin({
   typeDefs: gql`
     extend type Mutation {
       replaceGitHubPAT(pat: String!): Boolean
+    }
+    extend type Query {
+      databaseConnection: DisplayDatabaseConnection
+    }
+    type DisplayDatabaseConnection {
+      host: String
+      port: Int
+      database: String
+      user: String
     }
   `,
   resolvers: {
@@ -37,5 +50,15 @@ module.exports = makeExtendSchemaPlugin({
         }
       },
     },
+    Query: {
+      async databaseConnection(_parent: any, _args, _context: { pgClient: Client }, _info: any) {
+        return {
+          host: DISPLAY_PG_HOSTNAME || null,
+          port: DISPLAY_PG_PORT || null,
+          database: DISPLAY_PG_DATABASE || null,
+          user: DISPLAY_PG_USER || null,
+        }
+      }
+    }
   },
 });


### PR DESCRIPTION
set's up a new graphql query `databaseConnection` which returns the contents of the following ENV vars (if they are set):

- `DISPLAY_PG_HOSTNAME`
- `DISPLAY_PG_PORT`
- `DISPLAY_PG_DATABASE`
- `DISPLAY_PG_USER`

**Note** password is intentionally left out here since it's a secret. We'll omit that from the UI and maybe add a note saying users should get a password from their admin.

So that the UI can display them on the `/connect` page. The intent is that an operator will set these values ahead of time if they want to expose a DB connection string/params in the UI for easy use.

Next will be to implement the UI to use this `query`.

Closes #95 