### PR TITLE
feat: adding indexing to cover slow queries

### DIFF
--- a/migrations/20220920081312_add_indexing.up.sql
+++ b/migrations/20220920081312_add_indexing.up.sql
@@ -1,0 +1,26 @@
+CREATE INDEX IF NOT EXISTS idx_repo_sync_queue_status ON mergestat.repo_sync_queue
+(
+    status desc
+);
+
+CREATE INDEX IF NOT EXISTS idx_repo_sync_queue_created_at ON mergestat.repo_sync_queue
+(
+    created_at desc
+);
+
+CREATE INDEX IF NOT EXISTS idx_repo_sync_logs_repo_sync_queue_id ON mergestat.repo_sync_logs
+(
+    repo_sync_queue_id desc
+);
+
+CREATE INDEX IF NOT EXISTS idx_repo_sync_logs_repo_sync_created_at ON mergestat.repo_sync_logs
+(
+    created_at desc
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_issues_created_at_closed_at_database_id ON public.github_issues
+(
+    created_at desc,
+    closed_at desc,
+    database_id
+);


### PR DESCRIPTION
This PR is to cover the known slow queries that we have we will need to add indexes for all of the foreign keys to complete our indexing first pass.