### PR TITLE
fix: remove `commit_stats_pkey` PK for now

### DIFF
--- a/migrations/20220916222411_pk_commit_stats.up.sql
+++ b/migrations/20220916222411_pk_commit_stats.up.sql
@@ -1,6 +1,0 @@
-BEGIN;
-
-ALTER TABLE public.git_commit_stats
-ADD CONSTRAINT commit_stats_pkey PRIMARY KEY(repo_id, file_path, commit_hash);
-
-COMMIT


### PR DESCRIPTION
This is to address new deployments that encounter this migration. They _may_ hit a failure on duplicate key constraints because the columns here are not guaranteed to be unique (`file_path` alone is not unique enough within a commit, we saw an error with a submodule replacing a file).

By removing this migration, we protect future deployments from running this on against existing data.