### PR TITLE
feat: add `current_merge_stat_user` func to db

### DIFF
--- a/migrations/20220925185637_current_user_func.up.sql
+++ b/migrations/20220925185637_current_user_func.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Create a function that returns the current user, which can be called via the GraphQL API
+-- The `merge_stat` is included to avoid a name collision with the `current_user` function
+-- and the `_` is so when Graphile camelCases it, it becomes `currentMergeStatUser` (not `currentMergestatUser`)
+CREATE OR REPLACE FUNCTION current_merge_stat_user() RETURNS name AS $$ SELECT user $$ LANGUAGE sql STABLE;
+
+COMMIT;


### PR DESCRIPTION
This can now be accessed by PostGraphile so the UI can call `currentMergeStatuser` to retrieve the DB username of the currently authenticated user.

Closes #320