### PR TITLE
fix: adding drop constraint if it exists

### DIFF
--- a/migrations/20220927013137_git_commit_stats_file_modes.up.sql
+++ b/migrations/20220927013137_git_commit_stats_file_modes.up.sql
@@ -7,6 +7,9 @@ ADD COLUMN new_file_mode text;
 -- Add a primary key to the table, which was omitted previously because we didn't have enough columns
 -- to guarantee uniqueness. Now that we have file modes, we can guarantee uniqueness.
 ALTER TABLE public.git_commit_stats
+DROP CONSTRAINT IF EXISTS commit_stats_pkey;
+
+ALTER TABLE public.git_commit_stats
 ADD CONSTRAINT commit_stats_pkey PRIMARY KEY(repo_id, file_path, commit_hash, new_file_mode);
 
 COMMIT;


### PR DESCRIPTION
The is a fix for #304 as some of the databases had an existing PK.