### PR TITLE
feat: adding schema migrations history table

### DIFF
--- a/migrations/20220511014018_init.up.sql
+++ b/migrations/20220511014018_init.up.sql
@@ -426,3 +426,26 @@ INSERT INTO mergestat.repo_sync_types (type, description) VALUES ('GIT_REFS', 'R
 INSERT INTO mergestat.repo_sync_types (type, description) VALUES ('GITHUB_PR_REVIEWS', 'Pull request reviews') ON CONFLICT DO NOTHING;
 INSERT INTO mergestat.repo_sync_types (type, description) VALUES ('GITHUB_PR_COMMITS', 'Pull request commits') ON CONFLICT DO NOTHING;
 INSERT INTO mergestat.repo_sync_types (type, description) VALUES ('GIT_FILES', 'Get files of git repo') ON CONFLICT DO NOTHING;
+
+-- Schema Migrations History...adding to initial migration so we have history for new deployments
+CREATE TABLE IF NOT EXISTS public.schema_migrations_history (
+    id serial PRIMARY KEY NOT NULL,
+    version bigint NOT NULL,
+    applied_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION track_applied_migration()
+RETURNS trigger AS $$
+DECLARE _current_version BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(version),0) FROM public.schema_migrations_history INTO _current_version;
+    IF new.dirty = 'f' AND new.version > _current_version THEN
+        INSERT INTO public.schema_migrations_history(version) VALUES (new.version);
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- TRIGGER
+DROP TRIGGER IF EXISTS track_applied_migrations ON public.schema_migrations;
+CREATE TRIGGER track_applied_migrations AFTER INSERT ON public.schema_migrations FOR EACH ROW EXECUTE PROCEDURE track_applied_migration();

--- a/migrations/20220928141712_schema_migrations_history.up.sql
+++ b/migrations/20220928141712_schema_migrations_history.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.schema_migrations_history (
+    id serial PRIMARY KEY NOT NULL,
+    version bigint NOT NULL,
+    applied_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION track_applied_migration()
+RETURNS trigger AS $$
+DECLARE _current_version BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(version),0) FROM public.schema_migrations_history INTO _current_version;
+    IF new.dirty = 'f' AND new.version > _current_version THEN
+        INSERT INTO public.schema_migrations_history(version) VALUES (new.version);
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- TRIGGER
+DROP TRIGGER IF EXISTS track_applied_migrations ON public.schema_migrations;
+CREATE TRIGGER track_applied_migrations AFTER INSERT ON public.schema_migrations FOR EACH ROW EXECUTE PROCEDURE track_applied_migration();
+
+COMMIT;


### PR DESCRIPTION
Adding a Table, Function, and Trigger to track the history of our schema migrations. Currently the `schema_migrations` table only stores the latest migration so it is difficult to track what migrations were applied and when and this is an issue when troubleshooting failed or missed migrations.

The solution was found in an [issue](https://github.com/golang-migrate/migrate/issues/179#issuecomment-479740765) for our migration tool

Resolves #330 

Example output of the table on a clean database where all migrations ran
![image](https://user-images.githubusercontent.com/10135546/192883450-a90ec30b-0db3-45b5-9ac9-42f2259e8dfb.png)
