### PR TITLE
More verbose sync logs

### DIFF
--- a/internal/syncer/git_blame.go
+++ b/internal/syncer/git_blame.go
@@ -59,6 +59,11 @@ type blameLine struct {
 func (w *worker) handleGitBlame(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
+	// indicate that we're starting query execution
+	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
 	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
@@ -75,11 +80,6 @@ func (w *worker) handleGitBlame(ctx context.Context, j *db.DequeueSyncJobRow) er
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
-
-	// indicate that we're starting query execution
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
-		return fmt.Errorf("log messages: %w", err)
-	}
 
 	blamedLines := make([]*blameLine, 0)
 

--- a/internal/syncer/git_blame.go
+++ b/internal/syncer/git_blame.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -60,15 +59,11 @@ type blameLine struct {
 func (w *worker) handleGitBlame(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
-	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
 	}
-	defer func() {
-		if err := os.RemoveAll(tmpPath); err != nil {
-			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
-		}
-	}()
+	defer cleanup()
 
 	var ghToken string
 	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
@@ -76,7 +71,7 @@ func (w *worker) handleGitBlame(ctx context.Context, j *db.DequeueSyncJobRow) er
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, false); err != nil {
+	if repo, err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, false, j); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/jackc/pgx/v4"
 	libgit2 "github.com/libgit2/git2go/v33"
@@ -71,16 +70,11 @@ type commitStat struct {
 func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
-	// TODO(patrickdevivo) uplift the following os.Getenv call to one place, pass value down as a param
-	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
-		return err
+		return fmt.Errorf("temp dir: %w", err)
 	}
-	defer func() {
-		if err := os.RemoveAll(tmpPath); err != nil {
-			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
-		}
-	}()
+	defer cleanup()
 
 	var ghToken string
 	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
@@ -88,7 +82,7 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
+	if repo, err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, true, j); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -70,6 +70,11 @@ type commitStat struct {
 func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
+	// indicate that we're starting query execution
+	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
 	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
@@ -86,11 +91,6 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
-
-	// indicate that we're starting query execution
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
-		return fmt.Errorf("log messages: %w", err)
-	}
 
 	stats := make([]*commitStat, 0)
 

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -134,7 +134,16 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 		}
 	}()
 
-	if _, err := tx.Exec(ctx, "DELETE FROM git_commits WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+	r, err := tx.Exec(ctx, "DELETE FROM git_commits WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
+		return err
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from git_commits", r.RowsAffected()),
+	}}); err != nil {
 		return err
 	}
 
@@ -143,6 +152,14 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	}
 
 	l.Info().Msgf("sent batch of %d commits", len(commits))
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("inserted %d row(s) into git_commits", len(commits)),
+	}}); err != nil {
+		return err
+	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return err

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/jackc/pgx/v4"
 	libgit2 "github.com/libgit2/git2go/v33"
@@ -96,16 +95,11 @@ func collectCommits(ctx context.Context, repo *libgit2.Repository) ([]*commit, e
 func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
-	// TODO(patrickdevivo) uplift the following os.Getenv call to one place, pass value down as a param
-	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
-		return err
+		return fmt.Errorf("temp dir: %w", err)
 	}
-	defer func() {
-		if err := os.RemoveAll(tmpPath); err != nil {
-			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
-		}
-	}()
+	defer cleanup()
 
 	var ghToken string
 	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
@@ -113,7 +107,7 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	}
 
 	var repo *libgit2.Repository
-	if repo, err = w.cloneRepo(ghToken, j.Repo, tmpPath, true); err != nil {
+	if repo, err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, true, j); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -95,6 +95,11 @@ func collectCommits(ctx context.Context, repo *libgit2.Repository) ([]*commit, e
 func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
+	// indicate that we're starting query execution
+	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
 	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
@@ -111,11 +116,6 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 		return fmt.Errorf("git clone: %w", err)
 	}
 	defer repo.Free()
-
-	// indicate that we're starting query execution
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
-		return fmt.Errorf("log messages: %w", err)
-	}
 
 	commits, err := collectCommits(ctx, repo)
 	if err != nil {

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -152,17 +152,32 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 		}
 	}()
 
-	if res, err := tx.Exec(ctx, "DELETE FROM github_issues WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+	r, err := tx.Exec(ctx, "DELETE FROM github_issues WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
 		return fmt.Errorf("delete rows: %w", err)
-	} else {
-		l.Info().Msgf("deleted rows: %d", res.RowsAffected())
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from github_issues", r.RowsAffected()),
+	}}); err != nil {
+		return err
 	}
 
 	if err := w.sendBatchGitHubRepoIssues(ctx, tx, id, issues); err != nil {
 		return fmt.Errorf("insert issues: %w", err)
 	}
 
-	l.Info().Msgf("retrieved repo issues: %d", len(issues))
+	l.Info().Msgf("inserted repo issues: %d", len(issues))
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("inserted %d row(s) into github_issues", len(issues)),
+	}}); err != nil {
+		return err
+	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return fmt.Errorf("sync job done: %w", err)

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -203,17 +203,32 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 		}
 	}()
 
-	if res, err := tx.Exec(ctx, "DELETE FROM github_pull_requests WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+	r, err := tx.Exec(ctx, "DELETE FROM github_pull_requests WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
 		return fmt.Errorf("delete rows: %w", err)
-	} else {
-		l.Info().Msgf("deleted rows: %d", res.RowsAffected())
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from github_pull_requests", r.RowsAffected()),
+	}}); err != nil {
+		return err
 	}
 
 	if err := w.sendBatchGitHubRepoPRs(ctx, tx, id, prs); err != nil {
 		return fmt.Errorf("insert PRs: %w", err)
 	}
 
-	l.Info().Msgf("retrieved repo PRs: %d", len(prs))
+	l.Info().Msgf("inserted repo PRs: %d", len(prs))
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("inserted %d row(s) into github_pull_requests", len(prs)),
+	}}); err != nil {
+		return err
+	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return fmt.Errorf("sync job done: %w", err)

--- a/internal/syncer/handlers.go
+++ b/internal/syncer/handlers.go
@@ -32,16 +32,11 @@ type syncLog struct {
 
 // formartBatchLogMessages generates a standardize message for sync logs
 func (w *worker) formatBatchLogMessages(ctx context.Context, syncLogTypeOption syncLogType, j *db.DequeueSyncJobRow, status jobStatus) error {
-
-	formattedMessage := fmt.Sprintf("%s %s sync for %s", status, j.SyncType, j.Repo)
-	err := w.sendBatchLogMessages(ctx, []*syncLog{
-		{
-			Type:            syncLogTypeOption,
-			RepoSyncQueueID: j.ID,
-			Message:         formattedMessage,
-		}})
-
-	return err
+	return w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            syncLogTypeOption,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("%s %s sync for %s", status, j.SyncType, j.Repo),
+	}})
 }
 
 // sendBatchLogMessages uses the pg COPY protocol to send a batch of sync logs

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -206,8 +206,24 @@ func (w *worker) fetchGitHubTokenFromDB(ctx context.Context) (string, error) {
 	return string(credentials), nil
 }
 
+// createTempDirForGitClone creates a temporary directory for cloning a repository to
+// at a standardized path. The path is returned along with a cleanup function that should be called
+// at the end of a sync job, when the repository is no longer needed.
+func (w *worker) createTempDirForGitClone(job *db.DequeueSyncJobRow) (string, func(), error) {
+	tmpPath, err := os.MkdirTemp(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	if err != nil {
+		return "", nil, fmt.Errorf("temp dir: %w", err)
+	}
+
+	return tmpPath, func() {
+		if err := os.RemoveAll(tmpPath); err != nil {
+			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
+		}
+	}, nil
+}
+
 // cloneRepo is a helper function for cloning a repository to a path on disk
-func (w *worker) cloneRepo(ghToken, url, path string, bare bool) (*libgit2.Repository, error) {
+func (w *worker) cloneRepo(ctx context.Context, ghToken, url, path string, bare bool, job *db.DequeueSyncJobRow) (*libgit2.Repository, error) {
 	logger := w.logger.Info().Bool("bare", bare).Str("url", url).Bool("githubTokenSet", ghToken != "")
 
 	var creds *libgit2.Credential
@@ -218,6 +234,14 @@ func (w *worker) cloneRepo(ghToken, url, path string, bare bool) (*libgit2.Repos
 	defer creds.Free()
 
 	logger.Msgf("starting git repostory clone: %s", url)
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: job.ID,
+		Message:         "starting git clone: " + url,
+	}}); err != nil {
+		return nil, err
+	}
 
 	var credentialsCallback libgit2.CredentialsCallback
 	// only create a credentials callback if a token is provided
@@ -245,6 +269,14 @@ func (w *worker) cloneRepo(ghToken, url, path string, bare bool) (*libgit2.Repos
 	}
 
 	logger.Msgf("finished git repostory clone: %s", url)
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: job.ID,
+		Message:         "finished git clone successfully: " + url,
+	}}); err != nil {
+		return nil, err
+	}
 
 	return repo, nil
 }

--- a/internal/syncer/trivy_repo_scan.go
+++ b/internal/syncer/trivy_repo_scan.go
@@ -49,8 +49,17 @@ func (w *worker) handleTrivyRepoScan(ctx context.Context, j *db.DequeueSyncJobRo
 		}
 	}()
 
-	if _, err := tx.Exec(ctx, "DELETE FROM trivy_repo_scans WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+	r, err := tx.Exec(ctx, "DELETE FROM trivy_repo_scans WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
 		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from trivy_repo_scans", r.RowsAffected()),
+	}}); err != nil {
+		return err
 	}
 
 	if _, err := tx.Exec(ctx, "INSERT INTO trivy_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, output); err != nil {
@@ -58,6 +67,14 @@ func (w *worker) handleTrivyRepoScan(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	l.Info().Msg("inserted trivy scan results")
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         "inserted trivy scan results into trivy_repo_scans",
+	}}); err != nil {
+		return err
+	}
 
 	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
 		return fmt.Errorf("update status done: %w", err)


### PR DESCRIPTION
This adds more sync log insertions to the course of every sync job we have defined. It closes #232, but doesn't address _all_ of the bullets/suggestions in the ticket. This PR:

- [x] Adds start/end log entries for every `git clone` operation
- [x] Adds a log entry after rows are _removed_ during a sync run
- [x] Adds a log entry after rows are _inserted_ during a sync run

This _does not_ add log entries for every API request made to GitHub. This is because these are done via https://github.com/mergestat/mergestat and so we have a harder time accessing those events in the sync run flow.

This should be sufficient IMO to close out #232 for this first version.

<img width="785" alt="image" src="https://user-images.githubusercontent.com/57259/193413843-cbd367f9-38dd-4811-b41b-243205adc562.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/57259/193413817-c06d3463-ffb8-48be-a800-12a5a7f81473.png">
