### PR TITLE
Use sync type short name instead of the `type` enum

### DIFF
--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -10137,7 +10137,7 @@ export type GetSyncHistoryLogsQueryVariables = Exact<{
 }>;
 
 
-export type GetSyncHistoryLogsQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { description?: string | null } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any, doneAt?: any | null, startedAt?: any | null, repoSyncLogs: { totalCount: number, nodes: Array<{ logType: string, message: string, createdAt: any }> } }> } }> } } | null };
+export type GetSyncHistoryLogsQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string, description?: string | null } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any, doneAt?: any | null, startedAt?: any | null, repoSyncLogs: { totalCount: number, nodes: Array<{ logType: string, message: string, createdAt: any }> } }> } }> } } | null };
 
 export type GetLogsOfSyncQueryVariables = Exact<{
   repoId: Scalars['UUID'];
@@ -10146,4 +10146,4 @@ export type GetLogsOfSyncQueryVariables = Exact<{
 }>;
 
 
-export type GetLogsOfSyncQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { description?: string | null } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any, doneAt?: any | null, startedAt?: any | null, repoSyncLogs: { totalCount: number, nodes: Array<{ logType: string, message: string, createdAt: any }> } }> } }> } } | null };
+export type GetLogsOfSyncQuery = { repo?: { id: any, repo: string, isGithub?: boolean | null, repoSyncs: { nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string, description?: string | null } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any, doneAt?: any | null, startedAt?: any | null, repoSyncLogs: { totalCount: number, nodes: Array<{ logType: string, message: string, createdAt: any }> } }> } }> } } | null };

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -10129,7 +10129,7 @@ export type GetReposQueryVariables = Exact<{
 }>;
 
 
-export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, allRepos?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any }> } }> } }> } | null };
+export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, allRepos?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, createdAt: any }> } }> } }> } | null };
 
 export type GetSyncHistoryLogsQueryVariables = Exact<{
   repoId: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/queries/get-repos.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-repos.query.ts
@@ -23,11 +23,14 @@ const GET_REPOS = gql`
           type
           settings
         }
-        repoSyncs {
+        repoSyncs(orderBy: SYNC_TYPE_ASC) {
           totalCount
           nodes {
             id
             syncType
+            repoSyncTypeBySyncType {
+              shortName
+            }
             repoSyncQueues(first: 1, orderBy: CREATED_AT_DESC) {
               nodes {
                 id

--- a/ui/src/api-logic/graphql/queries/get-sync-history-logs.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-sync-history-logs.query.ts
@@ -11,6 +11,7 @@ const GET_SYNC_HISTORY_LOGS = gql`
           id
           syncType
           repoSyncTypeBySyncType {
+            shortName
             description
           }
           repoSyncQueues(first: 50, orderBy: CREATED_AT_DESC) {
@@ -47,6 +48,7 @@ const GET_LOGS_OF_A_SYNC = gql`
           id
           syncType
           repoSyncTypeBySyncType {
+            shortName
             description
           }
           repoSyncQueues(condition: {id: $logId}) {

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -59,7 +59,7 @@ const getSyncStatuses = (r: Repo, repoInfo: RepoDataPropsT): Array<RepoDataStatu
   const syncTypes = r?.repoSyncs.nodes.map((st: RepoSync) => {
     const syncObj: SyncTypeFlatten = {
       idType: st?.id,
-      type: capitalize(st?.syncType.replace(/_/ig, ' ')),
+      type: st?.repoSyncTypeBySyncType?.shortName || '',
       idLastSync: '',
       status: '',
       lastSync: ''

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -1,5 +1,5 @@
 import { RepoDataPropsT, RepoDataStatusT, RepoSyncStateT } from 'src/@types'
-import { capitalize, mapToRepoSyncStateT } from 'src/utils'
+import { mapToRepoSyncStateT } from 'src/utils'
 import { GITHUB_URL, SYNC_REPO_METHOD } from 'src/utils/constants'
 import { GetReposQuery, Repo, RepoSync, RepoSyncQueue } from '../graphql/generated/schema'
 

--- a/ui/src/api-logic/mappers/syncs-logs.ts
+++ b/ui/src/api-logic/mappers/syncs-logs.ts
@@ -23,7 +23,7 @@ const mapToSyncLogsData = (data: GetSyncHistoryLogsQuery | undefined): SyncTypeD
   data?.repo?.repoSyncs.nodes.forEach((s) => {
     repoData.sync = {
       id: s.id,
-      title: s?.syncType.replace(/_/ig, ' ') || '',
+      title: s?.repoSyncTypeBySyncType?.shortName || '',
       brief: s?.repoSyncTypeBySyncType?.description || '',
       syncState: s?.repoSyncQueues.nodes.length !== 0 ? mapToRepoSyncStateT(s?.repoSyncQueues.nodes[0]?.status || '') : SYNC_STATUS.empty,
     }


### PR DESCRIPTION
Previously we were using the `type` column of repo sync types (`GIT_COMMIT`, `GITHUB_REPO_PRS`, etc) to display repo sync type _names_ in some spots of the UI. Now that we track a human readable name in the `short_name` column, we should use that instead. This updates the UI to use that column in:

- [x] The repo sync detail breadcrumbs
- [x] The repo status popover on `/repos`

Closes #223 

<img width="785" alt="image" src="https://user-images.githubusercontent.com/57259/193417832-d175713b-265a-4451-8a31-30313589c68d.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/57259/193417855-5d9f0ef1-a430-4b48-b844-a336442fc4a6.png">
