### PR TITLE
feat: add a spinner to the auto import alert

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.6.9",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.2.8",
+        "@mergestat/blocks": "^1.4.0",
         "@mergestat/icons": "^1.1.2",
         "@next/bundle-analyzer": "^12.1.4",
         "axios": "^0.27.2",
@@ -2470,12 +2470,12 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.2.8.tgz",
-      "integrity": "sha512-8bv1iOedjfBAgQgzuXAAYejJxryujdOyyTxi3dDLbjTGkMXYn9XMmrcjWEY7ESAgs+Y3PIq7BOaxbkVMajXbWA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.0.tgz",
+      "integrity": "sha512-G85Z+Un7skzHXGp6eW2tJM4DhmO6eIBCgI0Emuq9wLyt0DtbBmApiXXeROG9Rz4sYc+vGyuweo/foisNA3/q4w==",
       "dependencies": {
         "@headlessui/react": "^1.4.1",
-        "@mergestat/icons": "^1.1.2",
+        "@mergestat/icons": "^1.2.0",
         "@tippyjs/react": "^4.2.6",
         "classnames": "^2.3.1",
         "rc-notification": "^4.5.7",
@@ -2488,6 +2488,21 @@
         "react-dom": "^17.0.2",
         "styled-components": "^5.2.3",
         "tailwindcss": "^2.2.19"
+      }
+    },
+    "node_modules/@mergestat/blocks/node_modules/@mergestat/icons": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.0.tgz",
+      "integrity": "sha512-HgZ+CFHr/6U3VOT9B+Vpi14AS7tF6rJqEIcLV+JRSXKluZ67eQ4tiqwIgLQVUXjoX+ittMgai+TCf9cfjTUwRA==",
+      "dependencies": {
+        "classnames": "^2.3.1"
+      },
+      "bin": {
+        "icons": "dist/index.cjs.js"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       }
     },
     "node_modules/@mergestat/icons": {
@@ -14343,17 +14358,27 @@
       }
     },
     "@mergestat/blocks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.2.8.tgz",
-      "integrity": "sha512-8bv1iOedjfBAgQgzuXAAYejJxryujdOyyTxi3dDLbjTGkMXYn9XMmrcjWEY7ESAgs+Y3PIq7BOaxbkVMajXbWA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.0.tgz",
+      "integrity": "sha512-G85Z+Un7skzHXGp6eW2tJM4DhmO6eIBCgI0Emuq9wLyt0DtbBmApiXXeROG9Rz4sYc+vGyuweo/foisNA3/q4w==",
       "requires": {
         "@headlessui/react": "^1.4.1",
-        "@mergestat/icons": "^1.1.2",
+        "@mergestat/icons": "^1.2.0",
         "@tippyjs/react": "^4.2.6",
         "classnames": "^2.3.1",
         "rc-notification": "^4.5.7",
         "react-overlays": "^5.1.1",
         "tippy.js": "^6.3.2"
+      },
+      "dependencies": {
+        "@mergestat/icons": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.0.tgz",
+          "integrity": "sha512-HgZ+CFHr/6U3VOT9B+Vpi14AS7tF6rJqEIcLV+JRSXKluZ67eQ4tiqwIgLQVUXjoX+ittMgai+TCf9cfjTUwRA==",
+          "requires": {
+            "classnames": "^2.3.1"
+          }
+        }
       }
     },
     "@mergestat/icons": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "^3.6.9",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.2.8",
+    "@mergestat/blocks": "^1.4.0",
     "@mergestat/icons": "^1.1.2",
     "@next/bundle-analyzer": "^12.1.4",
     "axios": "^0.27.2",

--- a/ui/src/views/repositories/index.tsx
+++ b/ui/src/views/repositories/index.tsx
@@ -4,7 +4,7 @@ import { AddRepositoryModal } from './modals/add-repository-modal'
 import { ManageAutoImportReposModal } from './modals/auto-import-repository-modals/manage-auto-imports-modal'
 import { SyncAutoImportReposModal } from './modals/auto-import-repository-modals/sync-auto-import-modal'
 
-import { Alert } from '@mergestat/blocks'
+import { Alert, Spinner } from '@mergestat/blocks'
 import Loading from 'src/components/Loading'
 import useRepos from 'src/views/hooks/useRepos'
 import { EmptyRepository } from './components/empty-repository'
@@ -22,7 +22,17 @@ const RepositoriesView: React.FC = () => {
       </div>
       <div className="flex-1 items-center p-8 overflow-auto">
         {showBanner &&
-          <Alert type="info" theme="light" title="Auto importing repos" className='mb-5'>
+          <Alert
+            type="info"
+            theme="light"
+            title={(
+              <div>
+                <span>Auto importing repos</span>
+                <div className='float-right'><Spinner size='sm' /></div>
+              </div>
+            )}
+            className='mb-5'
+          >
             Repositories from an auto-import will appear here once they are finished syncing.
           </Alert>
         }

--- a/ui/src/views/repositories/index.tsx
+++ b/ui/src/views/repositories/index.tsx
@@ -25,10 +25,10 @@ const RepositoriesView: React.FC = () => {
           <Alert
             type="info"
             theme="light"
+            icon={<Spinner size='sm' className='self-center' />}
             title={(
               <div>
                 <span>Auto importing repos</span>
-                <div className='float-right'><Spinner size='sm' /></div>
               </div>
             )}
             className='mb-5'


### PR DESCRIPTION
the message that's displayed when a repo auto import is running for the first time.

Closes #345 

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/57259/193424299-43a207f6-86ba-4221-9f4f-cbf42c3cd167.png">