### PR TITLE
feat: implement `SYFT_REPO_SCAN` sync type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY scripts/docker-init-entrypoint.sh docker-init-entrypoint.sh
 # install trivy binary for `TRIVY_REPO_SCAN` sync type
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.31.3
 
+# install syft binary
+RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.58.0
 
 # for pprof and prom metrics over http
 EXPOSE 8080

--- a/internal/syncer/syft_repo_scan.go
+++ b/internal/syncer/syft_repo_scan.go
@@ -1,0 +1,84 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/jackc/pgx/v4"
+	libgit2 "github.com/libgit2/git2go/v33"
+	"github.com/mergestat/fuse/internal/db"
+)
+
+// handleSyftRepoScan executes `syft {git-repo} -f json` for a repo
+// and inserts the output JSON into the DB
+func (w *worker) handleSyftRepoScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	// indicate that we're starting query execution
+	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	tmpPath, cleanup, err := w.createTempDirForGitClone(j)
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer cleanup()
+
+	var ghToken string
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	var repo *libgit2.Repository
+	if repo, err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, false, j); err != nil {
+		return fmt.Errorf("git clone: %w", err)
+	}
+	defer repo.Free()
+
+	cmd := exec.CommandContext(ctx, "syft", ".", "-o", "json")
+	cmd.Dir = tmpPath
+
+	var output []byte
+	if output, err = cmd.Output(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			w.logger.Err(exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running syft repo scan")
+		}
+		return fmt.Errorf("running syft scan: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, "DELETE FROM syft_repo_scans WHERE repo_id = $1;", j.RepoID.String()); err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, "INSERT INTO syft_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, output); err != nil {
+		return fmt.Errorf("inserting syft results: %w", err)
+	}
+
+	l.Info().Msg("inserted syft scan results")
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+
+	// indicate that we're finishing query execution
+	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish); err != nil {
+		return fmt.Errorf("log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -34,6 +34,7 @@ const (
 	syncTypeGitHubPRCommits    = "GITHUB_PR_COMMITS"
 
 	syncTypeTrivyRepoScan = "TRIVY_REPO_SCAN"
+	syncTypeSyftRepoScan  = "SYFT_REPO_SCAN"
 )
 
 type worker struct {
@@ -170,6 +171,8 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleGitHubPRCommits(ctx, j)
 	case syncTypeTrivyRepoScan:
 		return w.handleTrivyRepoScan(ctx, j)
+	case syncTypeSyftRepoScan:
+		return w.handleSyftRepoScan(ctx, j)
 	default:
 		return fmt.Errorf("unknown sync type: %s for job ID: %d", j.SyncType, j.ID)
 	}

--- a/migrations/20221002201938_syft_sync_support.up.sql
+++ b/migrations/20221002201938_syft_sync_support.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('SYFT_REPO_SCAN', 'Executes a syft scan on a git repository to generate an SBOM', 'Syft Repo Scan') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS syft_repo_scans (
+    repo_id uuid PRIMARY KEY,
+    results jsonb NOT NULL
+);
+
+CREATE OR REPLACE VIEW syft_repo_artifacts AS
+SELECT
+    syft_repo_scans.repo_id,
+    a::jsonb AS artifact,
+    a->>'id' AS id,
+    a->>'name' AS name,
+    a->>'version' AS version,
+    a->>'type' AS type,
+    a->>'foundBy' AS found_by,
+    a->>'locations' AS locations,
+    a->>'licenses' AS licenses,
+    a->>'language' AS language,
+    a->>'cpes' AS cpes,
+    a->>'purl' AS purl
+FROM syft_repo_scans, jsonb_array_elements(results->'artifacts') AS a;
+
+COMMIT;

--- a/migrations/20221002201938_syft_sync_support.up.sql
+++ b/migrations/20221002201938_syft_sync_support.up.sql
@@ -11,16 +11,16 @@ CREATE OR REPLACE VIEW syft_repo_artifacts AS
 SELECT
     syft_repo_scans.repo_id,
     a::jsonb AS artifact,
-    a->>'id' AS id,
-    a->>'name' AS name,
-    a->>'version' AS version,
-    a->>'type' AS type,
-    a->>'foundBy' AS found_by,
-    a->>'locations' AS locations,
-    a->>'licenses' AS licenses,
-    a->>'language' AS language,
-    a->>'cpes' AS cpes,
-    a->>'purl' AS purl
-FROM syft_repo_scans, jsonb_array_elements(results->'artifacts') AS a;
+    a->> 'id' AS id,
+    a->> 'name' AS name,
+    a->> 'version' AS version,
+    a->> 'type' AS type,
+    a->> 'foundBy' AS found_by,
+    a->> 'locations' AS locations,
+    a->> 'licenses' AS licenses,
+    a->> 'language' AS language,
+    a->> 'cpes' AS cpes,
+    a->> 'purl' AS purl
+FROM syft_repo_scans, jsonb_array_elements(results-> 'artifacts') AS a;
 
 COMMIT;


### PR DESCRIPTION
This PR should be merged _after_ #346.


`syft` (https://github.com/anchore/syft) is a CLI that generates SBOMs from various sources, including filesystems. This sync type implements a basic sync that uploads the results of `syft . -o json` on a git repo into the DB.

A view is also included with some simple JSON parsing to extract the `artifacts` list from the `syft` output JSON, for easier querying.

See here: https://github.com/anchore/syft for more context.