### PR TITLE
Small tweaks log entries empty

### DIFF
--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
@@ -94,7 +94,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({ logs }: LogsTableProps) =>
                       {log.collapsed && (
                         <tr>
                           <td colSpan={6} className="p-6 bg-gray-50">
-                            {log.logs?.length ? <LogBox logs={log.logs || []} onCopy={() => null} /> : <span className='text-semantic-mutedText'>No log entries yet</span>}
+                            {log.logs?.length ? <LogBox logs={log.logs || []} onCopy={() => null} /> : <span className='text-semantic-mutedText text-sm'>No log entries yet</span>}
                           </td>
                         </tr>
                       )}

--- a/ui/src/views/repository-data-logs-details/index.tsx
+++ b/ui/src/views/repository-data-logs-details/index.tsx
@@ -60,7 +60,7 @@ const RepoDataLogsDetailsView: React.FC<SyncTypeData> = ({ repo, sync, logs }) =
           ? <LogBox logs={logInfo?.logs || []} onCopy={() => null} />
           : (
             <Panel>
-              <Panel.Body className="flex items-center justify-center">
+              <Panel.Body className="flex items-center justify-center py-8">
                 <span className='text-semantic-mutedText text-sm'>No log entries yet</span>
               </Panel.Body>
             </Panel>)}

--- a/ui/src/views/repository-data-logs-details/index.tsx
+++ b/ui/src/views/repository-data-logs-details/index.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbNav, Button, LogBox } from '@mergestat/blocks'
+import { BreadcrumbNav, Button, LogBox, Panel } from '@mergestat/blocks'
 import { DotsHorizontalIcon, ExternalLinkIcon } from '@mergestat/icons'
 import { useRouter } from 'next/router'
 import React from 'react'
@@ -59,9 +59,11 @@ const RepoDataLogsDetailsView: React.FC<SyncTypeData> = ({ repo, sync, logs }) =
         {logInfo?.logs?.length
           ? <LogBox logs={logInfo?.logs || []} onCopy={() => null} />
           : (
-          <div className='m-5'>
-            <span className='text-semantic-mutedText'>No log entries yet</span>
-          </div>)}
+            <Panel>
+              <Panel.Body className="flex items-center justify-center">
+                <span className='text-semantic-mutedText text-sm'>No log entries yet</span>
+              </Panel.Body>
+            </Panel>)}
       </div>
     </main>
   )


### PR DESCRIPTION
Some small suggestions for the styling of the empty state of the logs:
<img width="1792" alt="Screenshot 2022-10-03 at 11 36 24" src="https://user-images.githubusercontent.com/36261498/193551028-fdd4d37a-5621-4ad2-aff2-f6a25e686286.png">
- smaller text size

<img width="1784" alt="Screenshot 2022-10-03 at 11 40 55" src="https://user-images.githubusercontent.com/36261498/193550999-8d9923ae-044c-4a3f-afe0-522802dbb648.png">

- Added empty state panel