### PR TITLE
fix: subtle bug when `CONCURRENCY` env can't be parsed

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -79,8 +79,10 @@ func main() {
 	var err error
 	concurrency := 1
 	if concurrencyEnv != "" {
-		if concurrency, err = strconv.Atoi(concurrencyEnv); err != nil {
+		if c, err := strconv.Atoi(concurrencyEnv); err != nil {
 			logger.Err(err).Msgf("could not parse CONCURRENCY env into an int: %s", concurrencyEnv)
+		} else {
+			concurrency = c
 		}
 	}
 


### PR DESCRIPTION
We encountered this in a deployment, where the `CONCURRENCY` env could not be parsed, and so the `concurrency` _var_ in this part of the code got _set to `0`_, which is unexpected behavior. It should respect the default value (current `1`).

This should address that.