### PR TITLE
fix: remove extra (unnecessary) checkbox card

### DIFF
--- a/ui/src/views/repositories/modals/add-repository-modal/modal-sidebar.tsx
+++ b/ui/src/views/repositories/modals/add-repository-modal/modal-sidebar.tsx
@@ -64,11 +64,6 @@ const sidebarTabs: SideBarTab[] = [
     type: ADD_REPO.url,
   },
   {
-    startIcon: <GithubIcon className='t-icon' />,
-    label: 'Auto import from GitHub',
-    type: ADD_REPO.ghAuto,
-  },
-  {
     startIcon: <TableIcon className='t-icon' />,
     label: 'Add from CSV',
     type: ADD_REPO.csv,


### PR DESCRIPTION
Removes the double option for automatic repo import

![image](https://user-images.githubusercontent.com/57259/195222583-27ec8f1f-c310-45e4-b117-7296819ad425.png)
