### PR TITLE
fix: commenting out the sync status bar tooltip for now

### DIFF
--- a/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-status.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-status.tsx
@@ -87,7 +87,7 @@ export const RepositorySyncStatus: React.FC<RepositorySyncStatusProps> = (
 
   return (
     <>
-      {/** Tooltip */}
+      {/* * Tooltip
       {(displayTooltip && tooltipData?.status !== SYNC_STATUS.empty) && (
         <div
           ref={tooltipRef}
@@ -119,7 +119,7 @@ export const RepositorySyncStatus: React.FC<RepositorySyncStatusProps> = (
             </div>
           </div>
         </div>
-      )}
+      )} */}
 
       {/** Bars */}
       <div


### PR DESCRIPTION
I think we should address the bugginess in it before turning it back on. I'd like to use a library for this, something like this: https://popper.js.org/react-popper/v2/